### PR TITLE
Move to new user tasks list API when fetching tasks via :my_tasks

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    checkoff (0.11.0)
+    checkoff (0.11.1)
       activesupport
       asana (> 0.10.0)
       cache_method

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    checkoff (0.10.0)
+    checkoff (0.10.1)
       activesupport
       asana (> 0.10.0)
       cache_method
@@ -28,15 +28,19 @@ GEM
     cache_method (0.2.7)
       cache (>= 0.2.1)
     childprocess (4.0.0)
-    concurrent-ruby (1.1.8)
+    concurrent-ruby (1.1.9)
     dalli (2.7.11)
     docile (1.4.0)
-    faraday (1.4.1)
+    faraday (1.4.2)
+      faraday-em_http (~> 1.0)
+      faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)
       faraday-net_http (~> 1.0)
       faraday-net_http_persistent (~> 1.1)
       multipart-post (>= 1.2, < 3)
       ruby2_keywords (>= 0.0.4)
+    faraday-em_http (1.0.0)
+    faraday-em_synchrony (1.0.0)
     faraday-excon (1.1.0)
     faraday-net_http (1.0.1)
     faraday-net_http_persistent (1.1.0)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ $ checkoff --help
 View tasks:
   checkoff view workspace project [section]
 
-'project' can be set to a project name, or :my_tasks, :my_tasks_upcoming, :my_tasks_new, or :my_tasks_today
+'project' can be set to a project name, or :my_tasks for your user task list.
 ```
 
 Let's say we have a project like this:

--- a/coverage/.last_run.json
+++ b/coverage/.last_run.json
@@ -1,6 +1,6 @@
 {
   "result": {
-    "line": 94.61,
-    "branch": 71.42
+    "line": 97.0,
+    "branch": 80.95
   }
 }

--- a/lib/checkoff/projects.rb
+++ b/lib/checkoff/projects.rb
@@ -35,6 +35,17 @@ module Checkoff
       @workspaces.client
     end
 
+    # Default options used in Asana API to pull taskso
+    def task_options
+      {
+        per_page: 100,
+        options: {
+          fields: %w[name completed_at due_at due_on tags
+                     memberships.project.gid memberships.section.name dependencies],
+        },
+      }
+    end
+
     # pulls an Asana API project class given a name
     def project(workspace_name, project_name)
       if project_name.is_a?(Symbol) && project_name.to_s.start_with?('my_tasks')
@@ -83,16 +94,6 @@ module Checkoff
                                                                   workspace: workspace.gid)
       gid = result.gid
       projects.find_by_id(gid)
-    end
-
-    def task_options
-      {
-        per_page: 100,
-        options: {
-          fields: %w[name completed_at due_at due_on assignee_status tags
-                     memberships.project.gid memberships.section.name dependencies],
-        },
-      }
     end
   end
 end

--- a/lib/checkoff/sections.rb
+++ b/lib/checkoff/sections.rb
@@ -4,7 +4,6 @@ require 'forwardable'
 
 module Checkoff
   # Query different sections of Asana projects
-  # rubocop:disable Metrics/ClassLength
   class Sections
     MINUTE = 60
     LONG_CACHE_TIME = MINUTE * 15
@@ -60,17 +59,6 @@ module Checkoff
       tasks.map(&:name)
     end
     cache_method :section_task_names, SHORT_CACHE_TIME
-
-    # returns if a task's due field is at or before the current date/time
-    def task_due?(task)
-      if task.due_at
-        Time.parse(task.due_at) <= time.now
-      elsif task.due_on
-        Date.parse(task.due_on) <= time.today
-      else
-        true # set a due date if you don't want to do this now
-      end
-    end
 
     private
 
@@ -128,19 +116,5 @@ module Checkoff
       end
       section
     end
-
-    def project_task_names(workspace_name, project_name)
-      by_section = tasks_by_section(workspace_name, project_name)
-      by_section.flat_map do |section_name, tasks|
-        task_names = tasks.map(&:name)
-        if section_name.nil?
-          task_names
-        else
-          [section_name, task_names]
-        end
-      end
-    end
-    cache_method :project_task_names, SHORT_CACHE_TIME
   end
-  # rubocop:enable Metrics/ClassLength
 end

--- a/lib/checkoff/sections.rb
+++ b/lib/checkoff/sections.rb
@@ -23,6 +23,12 @@ module Checkoff
       @time = time
     end
 
+    # Returns a list of Asana API section objects for a given project
+    def sections_or_raise(workspace_name, project_name)
+      project = project_or_raise(workspace_name, project_name)
+      client.sections.get_sections_for_project(project_gid: project.gid)
+    end
+
     # Given a project object, pull all tasks, then provide a Hash of
     # tasks with section name -> task list of the uncompleted tasks
     def tasks_by_section_for_project(project)
@@ -114,8 +120,7 @@ module Checkoff
     end
 
     def section(workspace_name, project_name, section_name)
-      project = project_or_raise(workspace_name, project_name)
-      sections = client.sections.get_sections_for_project(project_gid: project.gid)
+      sections = sections_or_raise(workspace_name, project_name)
       sections.find { |section| section.name.chomp(':') == section_name.chomp(':') }
     end
 

--- a/lib/checkoff/sections.rb
+++ b/lib/checkoff/sections.rb
@@ -29,14 +29,6 @@ module Checkoff
       client.sections.get_sections_for_project(project_gid: project.gid)
     end
 
-    # Given a project object, pull all tasks, then provide a Hash of
-    # tasks with section name -> task list of the uncompleted tasks
-    def tasks_by_section_for_project(project)
-      raw_tasks = projects.tasks_from_project(project)
-      active_tasks = projects.active_tasks(raw_tasks)
-      by_section(active_tasks, project.gid)
-    end
-
     # Given a workspace name and project name, then provide a Hash of
     # tasks with section name -> task list of the uncompleted tasks
     def tasks_by_section(workspace_name, project_name)
@@ -87,6 +79,14 @@ module Checkoff
     end
 
     private
+
+    # Given a project object, pull all tasks, then provide a Hash of
+    # tasks with section name -> task list of the uncompleted tasks
+    def tasks_by_section_for_project(project)
+      raw_tasks = projects.tasks_from_project(project)
+      active_tasks = projects.active_tasks(raw_tasks)
+      by_section(active_tasks, project.gid)
+    end
 
     def_delegators :@projects, :client
 

--- a/lib/checkoff/sections.rb
+++ b/lib/checkoff/sections.rb
@@ -57,12 +57,6 @@ module Checkoff
     # Pulls just names of tasks from a given section.
     def section_task_names(workspace_name, project_name, section_name)
       tasks = tasks(workspace_name, project_name, section_name)
-      if tasks.nil?
-        by_section = tasks_by_section(workspace_name, project_name)
-        desc = "#{workspace_name} | #{project_name} | #{section_name}"
-        raise "Could not find task names for #{desc}.  " \
-              "Valid sections: #{by_section.keys}"
-      end
       tasks.map(&:name)
     end
     cache_method :section_task_names, SHORT_CACHE_TIME
@@ -127,8 +121,10 @@ module Checkoff
     def section_or_raise(workspace_name, project_name, section_name)
       section = section(workspace_name, project_name, section_name)
       if section.nil?
+        valid_sections = sections_or_raise(workspace_name, project_name).map(&:name)
+
         raise "Could not find section #{section_name} under project #{project_name} " \
-              "under workspace #{workspace_name}"
+              "under workspace #{workspace_name}.  Valid sections: #{valid_sections}"
       end
       section
     end

--- a/lib/checkoff/sections.rb
+++ b/lib/checkoff/sections.rb
@@ -23,16 +23,6 @@ module Checkoff
       @time = time
     end
 
-    # Given a list of tasks, pull a Hash of tasks with section name -> task list
-    def by_section(tasks, project_gid)
-      by_section = {}
-      tasks.each do |task|
-        file_task_by_section(by_section, task, project_gid)
-      end
-      by_section
-    end
-    cache_method :by_section, LONG_CACHE_TIME
-
     # Given a project object, pull all tasks, then provide a Hash of
     # tasks with section name -> task list of the uncompleted tasks
     def tasks_by_section_for_project(project)
@@ -64,7 +54,7 @@ module Checkoff
       client.tasks.get_tasks_for_section(section_gid: section.gid,
                                          **options).to_a
     end
-    # cache_method :tasks, SHORT_CACHE_TIME # TODO restore
+    cache_method :tasks, SHORT_CACHE_TIME
 
     # Pulls just names of tasks from a given section.
     def section_task_names(workspace_name, project_name, section_name)
@@ -93,6 +83,16 @@ module Checkoff
     private
 
     def_delegators :@projects, :client
+
+    # Given a list of tasks, pull a Hash of tasks with section name -> task list
+    def by_section(tasks, project_gid)
+      by_section = {}
+      tasks.each do |task|
+        file_task_by_section(by_section, task, project_gid)
+      end
+      by_section
+    end
+    cache_method :by_section, LONG_CACHE_TIME
 
     def file_task_by_section(by_section, task, project_gid)
       membership = task.memberships.find { |m| m['project']['gid'] == project_gid }

--- a/lib/checkoff/tasks.rb
+++ b/lib/checkoff/tasks.rb
@@ -54,10 +54,6 @@ module Checkoff
       @projects ||= @sections.projects
     end
 
-    def tasks_minus_sections(tasks)
-      @sections.by_section(tasks).values.flatten
-    end
-
     def default_assignee_gid
       @config.fetch(:default_assignee_gid)
     end

--- a/lib/checkoff/version.rb
+++ b/lib/checkoff/version.rb
@@ -2,5 +2,5 @@
 
 module Checkoff
   # Version of library
-  VERSION = '0.11.0'
+  VERSION = '0.11.1'
 end

--- a/lib/checkoff/version.rb
+++ b/lib/checkoff/version.rb
@@ -2,5 +2,5 @@
 
 module Checkoff
   # Version of library
-  VERSION = '0.10.0'
+  VERSION = '0.10.1'
 end

--- a/test/unit/base_asana.rb
+++ b/test/unit/base_asana.rb
@@ -20,7 +20,7 @@ class BaseAsana < ClassTest
     {
       per_page: 100,
       options: {
-        fields: %w[name completed_at due_at due_on assignee_status tags
+        fields: %w[name completed_at due_at due_on tags
                    memberships.project.gid memberships.section.name dependencies],
       },
       completed_since: '9999-12-01',

--- a/test/unit/test_sections.rb
+++ b/test/unit/test_sections.rb
@@ -45,6 +45,24 @@ class TestSections < BaseAsana
     assert_equal([section1, section2], sections.sections_or_raise('Workspace 1', a_name))
   end
 
+  def mock_tasks_by_section_missing_membership
+    expect_project_pulled('Workspace 1', project_a, :my_tasks)
+    expect_tasks_pulled(project_a, [task_a, task_b, task_c],
+                        [task_c])
+    expect_project_gid_pulled(project_a, a_gid)
+    task_c.expects(:memberships).returns([])
+  end
+
+  def test_tasks_by_section_missing_membership
+    # This can happen as of 2021-07-22 if called with :my_tasks as a
+    # section, due to a limitation in the early implementation of the
+    # breaking change around user tasks lists.
+    sections = get_test_object do
+      mock_tasks_by_section_missing_membership
+    end
+    assert_raises(RuntimeError) { sections.tasks_by_section('Workspace 1', :my_tasks) }
+  end
+
   def test_tasks_by_section_some_in_empty_section
     sections = get_test_object do
       expect_tasks_and_sections_pulled('Workspace 1', project_a, a_name, '(no section)')

--- a/test/unit/test_sections.rb
+++ b/test/unit/test_sections.rb
@@ -52,35 +52,8 @@ class TestSections < BaseAsana
     assert_equal({ 'Section 1:' => [task_c] }, sections.tasks_by_section('Workspace 1', a_name))
   end
 
-  def expect_workspace_pulled(workspace_name, workspace)
-    @mocks[:workspaces].expects(:workspace_by_name).with(workspace_name).returns(workspace)
-  end
-
-  def expect_legacy_project_and_workspace_pulled(workspace_name, workspace, project, project_name)
-    expect_project_pulled(workspace_name, project, project_name)
-    expect_workspace_pulled(workspace_name, workspace)
-  end
-
   def expect_client_pulled
     @mocks[:projects].expects(:client).returns(client).at_least(1)
-  end
-
-  def expect_user_task_lists_object_pulled_from_client
-    client.expects(:user_task_lists).returns(user_task_lists)
-  end
-
-  def expect_user_task_lists_queried
-    user_task_lists.expects(:get_user_task_list_for_user).with(user_gid: 'me',
-                                                               workspace: workspace_one_gid)
-      .returns(user_task_list)
-  end
-
-  def expect_user_task_list_pulled
-    expect_client_pulled
-    expect_user_task_lists_object_pulled_from_client
-    workspace_one.expects(:gid).returns(workspace_one_gid)
-    expect_user_task_lists_queried
-    user_task_list.expects(:migration_status).returns('not_migrated')
   end
 
   def expect_named(task, name)
@@ -219,34 +192,7 @@ class TestSections < BaseAsana
     end
   end
 
-  def expect_today_pulled
-    @mocks[:time].expects(:today).returns(mock_date)
-  end
-
-  def mock_task_due_by_due_on
-    task_a.expects(:due_at).returns(nil)
-    task_a
-      .expects(:due_on)
-      .returns((mock_date - 1.day).to_s)
-      .at_least(1)
-    expect_today_pulled
-  end
-
-  def expect_now_pulled
-    @mocks[:time].expects(:now).returns(mock_now).at_least(0)
-  end
-
   let_mock :subtasks
-
-  def expect_task_options_pulled
-    @mocks[:projects].expects(:task_options).returns(task_options)
-  end
-
-  def mock_raw_subtasks
-    expect_task_options_pulled
-    task_a.expects(:subtasks).with(task_options).returns(subtasks)
-    task_a.expects(:name).returns('task a').at_least(0)
-  end
 
   def class_under_test
     Checkoff::Sections

--- a/test/unit/test_tasks.rb
+++ b/test/unit/test_tasks.rb
@@ -12,23 +12,6 @@ class TestTasks < BaseAsana
   let_mock :mock_tasks, :modified_mock_tasks, :tasks_by_section,
            :unflattened_modified_mock_tasks
 
-  def mock_tasks_minus_sections
-    @mocks[:sections]
-      .expects(:by_section).with(mock_tasks)
-      .returns(tasks_by_section)
-    tasks_by_section.expects(:values).returns(unflattened_modified_mock_tasks)
-    unflattened_modified_mock_tasks
-      .expects(:flatten).returns(modified_mock_tasks)
-  end
-
-  def test_tasks_minus_sections
-    tasks = get_test_object do
-      mock_tasks_minus_sections
-    end
-    assert_equal(modified_mock_tasks,
-                 tasks.send(:tasks_minus_sections, mock_tasks))
-  end
-
   let_mock :workspace_gid, :task_name, :default_assignee_gid
 
   def expect_task_created


### PR DESCRIPTION
Remove support for workspaces using legacy user task lists API.  Use
older checkoff versions for that.

Remove support for :my_tasks_upcoming, :my_tasks_new, :my_tasks_today
as these are no longer hard-coded Asana-provided concepts.  Section
names can now be used directly with :my_tasks as the project.

Use sections API directly when fetching tasks for a section;
compatible with current bugs in Asana user task lists API, and should
be faster for small sections in big projects, but may trigger issues
on big sections due to paging-related SDK limitation.  Possible
ruby-asana PR needed in the future...