### PR TITLE
Handle multiple inbox section names seen in practice

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,10 +98,6 @@ $
 Since checkoff looks up things by their name, if you have two things
 with the same name, you're probably going to have a bad time.
 
-If you need to talk about the section of a project which contains
-tasks that don't have a section, use `Untitled section` as the name.
-This is a quirk of the Asana API which seemed as good as any other idea.
-
 ## Caching
 
 Note that I don't know of a way through the Asana API to target

--- a/lib/checkoff/sections.rb
+++ b/lib/checkoff/sections.rb
@@ -103,7 +103,7 @@ module Checkoff
       raise "Could not find task in project_gid #{project_gid}: #{task}" if membership.nil?
 
       current_section = membership['section']['name']
-      current_section = nil if current_section == '(no section)'
+      current_section = nil if ['(no section)', 'Untitled section'].include?(current_section)
       by_section[current_section] ||= []
       by_section[current_section] << task
     end


### PR DESCRIPTION
It appears that the inbox section name varies, either by project or some other variable on the Asana backend.  This handles the two names I've seen so far.