### PR TITLE
Stop caching task results in sections project

### DIFF
--- a/lib/checkoff/my_tasks.rb
+++ b/lib/checkoff/my_tasks.rb
@@ -42,6 +42,5 @@ module Checkoff
       end
       by_section
     end
-    cache_method :by_my_tasks_section, LONG_CACHE_TIME
   end
 end

--- a/lib/checkoff/sections.rb
+++ b/lib/checkoff/sections.rb
@@ -46,7 +46,6 @@ module Checkoff
         tasks_by_section_for_project(project)
       end
     end
-    cache_method :tasks_by_section, SHORT_CACHE_TIME
 
     # XXX: Rename to section_tasks
     #


### PR DESCRIPTION
ruby-asana results from 'My Tasks' section appear to not be
serializable :(  Results from other projects seem OK, but go through
the same interface.

They will need to be cached further upstream.

```
E, [2022-04-26T17:42:07.496886 #19196] ERROR -- : Marshalling error for key 'CacheMethod,CachedResult,Checkoff::Sections#tasks_by_section,625502a5560a3453c42eabf387cc08ea5b2c5811,20437277609,21d3da2cc7651962122f9b7f0df7c6f550d74e16': singleton can't be dumped
E, [2022-04-26T17:42:07.496930 #19196] ERROR -- : You are trying to cache a Ruby object which cannot be serialized to memcached.
E, [2022-04-26T17:42:07.496941 #19196] ERROR -- : /Users/broz/.rbenv/versions/2.6.8/lib/ruby/gems/2.6.0/gems/dalli-2.7.11/lib/dalli/server.rb:413:in `dump'
	/Users/broz/.rbenv/versions/2.6.8/lib/ruby/gems/2.6.0/gems/dalli-2.7.11/lib/dalli/server.rb:413:in `serialize'
	/Users/broz/.rbenv/versions/2.6.8/lib/ruby/gems/2.6.0/gems/dalli-2.7.11/lib/dalli/server.rb:285:in `set'
	/Users/broz/.rbenv/versions/2.6.8/lib/ruby/gems/2.6.0/gems/dalli-2.7.11/lib/dalli/server.rb:70:in `request'
	/Users/broz/.rbenv/versions/2.6.8/lib/ruby/gems/2.6.0/gems/dalli-2.7.11/lib/dalli/options.rb:19:in `block in request'
	/Users/broz/.rbenv/versions/2.6.8/lib/ruby/2.6.0/monitor.rb:235:in `mon_synchronize'
	/Users/broz/.rbenv/versions/2.6.8/lib/ruby/gems/2.6.0/gems/dalli-2.7.11/lib/dalli/options.rb:18:in `request'
	/Users/broz/.rbenv/versions/2.6.8/lib/ruby/gems/2.6.0/gems/dalli-2.7.11/lib/dalli/client.rb:371:in `perform'
	/Users/broz/.rbenv/versions/2.6.8/lib/ruby/gems/2.6.0/gems/dalli-2.7.11/lib/dalli/client.rb:131:in `set'
	/Users/broz/.rbenv/versions/2.6.8/lib/ruby/gems/2.6.0/gems/cache-0.4.1/lib/cache/dalli_client.rb:15:in `_set'
	/Users/broz/.rbenv/versions/2.6.8/lib/ruby/gems/2.6.0/gems/cache-0.4.1/lib/cache.rb:77:in `set'
	/Users/broz/.rbenv/versions/2.6.8/lib/ruby/gems/2.6.0/gems/cache_method-0.2.7/lib/cache_method/cached_result.rb:72:in `set_wrapped'
	/Users/broz/.rbenv/versions/2.6.8/lib/ruby/gems/2.6.0/gems/cache_method-0.2.7/lib/cache_method/cached_result.rb:32:in `fetch'
	/Users/broz/.rbenv/versions/2.6.8/lib/ruby/gems/2.6.0/gems/cache_method-0.2.7/lib/cache_method.rb:99:in `block in cache_method'
	/Users/broz/src/checkoff/lib/checkoff/cli.rb:163:in `run_on_project'
	/Users/broz/src/checkoff/lib/checkoff/cli.rb:143:in `run'
	/Users/broz/src/checkoff/lib/checkoff/cli.rb:257:in `block (2 levels) in <class:CheckoffGLIApp>'
	/Users/broz/.rbenv/versions/2.6.8/lib/ruby/gems/2.6.0/gems/gli-2.20.1/lib/gli/command_support.rb:131:in `execute'
	/Users/broz/.rbenv/versions/2.6.8/lib/ruby/gems/2.6.0/gems/gli-2.20.1/lib/gli/app_support.rb:296:in `block in call_command'
	/Users/broz/.rbenv/versions/2.6.8/lib/ruby/gems/2.6.0/gems/gli-2.20.1/lib/gli/app_support.rb:309:in `call_command'
	/Users/broz/.rbenv/versions/2.6.8/lib/ruby/gems/2.6.0/gems/gli-2.20.1/lib/gli/app_support.rb:83:in `run'
	/Users/broz/src/checkoff/exe/checkoff:7:in `<top (required)>'
	/Users/broz/src/checkoff/bin/checkoff:29:in `load'
	/Users/broz/src/checkoff/bin/checkoff:29:in `<main>'
```