### PR TITLE
Fix custom_field_#{gid}.variant = 'no_value' in search URL parsing

### DIFF
--- a/lib/checkoff/internal/search_url/custom_field_variant.rb
+++ b/lib/checkoff/internal/search_url/custom_field_variant.rb
@@ -100,8 +100,15 @@ module Checkoff
               raise "Teach me how to handle these remaining keys for #{variant_key}: #{remaining_params}"
             end
 
-            empty_task_selector = []
-            [{ "custom_fields.#{gid}.is_set" => 'false' }, empty_task_selector]
+            api_params = { "custom_fields.#{gid}.is_set" => 'false' }
+            # As of 2023-02, the 'is_set' => 'false' seems to not do
+            # the intuitive thing on multi-select fields; it either
+            # operates as a no-op or operates the same as 'true'; not
+            # sure.
+            #
+            # Let's handle those with a filter afterwards.
+            task_selector = [:nil?, [:custom_field_gid_value, gid]]
+            [api_params, task_selector]
           end
         end
 

--- a/test/unit/internal/test_search_url_parser.rb
+++ b/test/unit/internal/test_search_url_parser.rb
@@ -13,7 +13,7 @@ class TestSearchUrlParser < ClassTest
       'custom_fields.456.value' => '789',
       'custom_fields.1234.is_set' => 'false',
     }
-    task_selector = []
+    task_selector = [:nil?, [:custom_field_gid_value, '1234']]
     assert_equal([asana_api_params, task_selector],
                  search_url_parser.convert_params(url))
   end
@@ -26,7 +26,7 @@ class TestSearchUrlParser < ClassTest
       'custom_fields.456.is_set' => 'false',
       'custom_fields.789.value' => '1234',
     }
-    task_selector = []
+    task_selector = [:nil?, [:custom_field_gid_value, '456']]
     assert_equal([asana_api_params, task_selector],
                  search_url_parser.convert_params(url))
   end
@@ -41,7 +41,11 @@ class TestSearchUrlParser < ClassTest
       'custom_fields.5678.is_set' => 'true',
       'custom_fields.34.less_than' => '100',
     }
-    task_selector = ['not', ['custom_field_gid_value_contains_any_gid', '5678', ['12']]]
+
+    task_selector = [:and,
+                     [:nil?, [:custom_field_gid_value, '456']],
+                     ['not', ['custom_field_gid_value_contains_any_gid', '5678', ['12']]]]
+
     assert_equal([asana_api_params, task_selector],
                  search_url_parser.convert_params(url))
   end
@@ -65,7 +69,7 @@ class TestSearchUrlParser < ClassTest
       'completed' => false,
       'projects.any' => '123',
     }
-    task_selector = []
+    task_selector = [:nil?, [:custom_field_gid_value, '456']]
     assert_equal([asana_api_params, task_selector],
                  search_url_parser.convert_params(url))
   end
@@ -82,7 +86,7 @@ class TestSearchUrlParser < ClassTest
       'tags.not' => '123,456,789',
       'projects.any' => '1234',
     }
-    task_selector = []
+    task_selector = [:nil?, [:custom_field_gid_value, '5678']]
     assert_equal([asana_api_params, task_selector],
                  search_url_parser.convert_params(url))
   end


### PR DESCRIPTION
As of 2023-02, the 'is_set' => 'false' parameter to the task search API seems to not do the intuitive thing on multi-select fields; it either operates as a no-op or operates the same as 'true'; not sure.

Let's handle that case with a client-side filter afterwards.