### PR TITLE
Opt in to memberships related deprecation

### DIFF
--- a/lib/checkoff/clients.rb
+++ b/lib/checkoff/clients.rb
@@ -27,7 +27,7 @@ module Checkoff
     def client
       @client ||= @asana_client_class.new do |c|
         c.authentication :access_token, @config.fetch(:personal_access_token)
-        c.default_headers 'asana-enable' => 'new_project_templates,new_user_task_lists'
+        c.default_headers 'asana-enable' => 'new_project_templates,new_user_task_lists,new_memberships'
       end
     end
 

--- a/test/unit/test_clients.rb
+++ b/test/unit/test_clients.rb
@@ -19,7 +19,7 @@ class TestClients < ClassTest
     config.expects(:fetch).with(:personal_access_token).returns(personal_access_token)
     client.expects(:authentication).with(:access_token, personal_access_token)
     client.expects(:default_headers)
-      .with('asana-enable' => 'new_project_templates,new_user_task_lists')
+      .with('asana-enable' => 'new_project_templates,new_user_task_lists,new_memberships')
   end
 
   def test_client


### PR DESCRIPTION
Avoids this warning:

This request is affected by the "new_memberships" deprecation. Please
visit this url for more info:
https://forum.asana.com/t/upcoming-changes-that-impact-getting-and-setting-memberships-and-access-levels/232106?u

Adding "new_memberships" to your "Asana-Enable" or "Asana-Disable" header will opt in/out to this deprecation and suppress this warning.