### PR TITLE
Handle estimate-less tasks in :estimate_exceeds_duration selector

### DIFF
--- a/lib/checkoff/internal/selector_classes/task.rb
+++ b/lib/checkoff/internal/selector_classes/task.rb
@@ -335,7 +335,9 @@ module Checkoff
         # @param task [Asana::Resources::Task]
         # @return [Boolean]
         def evaluate(task)
-          custom_field = pull_custom_field_by_name_or_raise(task, 'Estimated time')
+          custom_field = pull_custom_field_by_name(task, 'Estimated time')
+
+          return false if custom_field.nil?
 
           # @sg-ignore
           # @type [Integer, nil]

--- a/test/unit/test_task_selectors.rb
+++ b/test/unit/test_task_selectors.rb
@@ -587,17 +587,10 @@ class TestTaskSelectors < ClassTest
   def test_estimate_exceeds_duration_no_estimate_field
     task_selectors = get_test_object do
       task.expects(:custom_fields).returns([]).at_least(1)
-      task.expects(:gid).returns('123')
     end
 
-    e = assert_raises(RuntimeError) do
-      # @sg-ignore
-      task_selectors.filter_via_task_selector(task,
-                                              [:estimate_exceeds_duration])
-    end
-
-    assert_match(/Could not find custom field with name Estimated time in task 123 with custom fields/,
-                 e.message)
+    refute(task_selectors.filter_via_task_selector(task,
+                                                   [:estimate_exceeds_duration]))
   end
 
   # @return [void]


### PR DESCRIPTION
Teach :estimate_exceeds_duration task selector to handle no-estimate-field case