### PR TITLE
Add Tasks#task_to_h

### DIFF
--- a/config/definitions.rb
+++ b/config/definitions.rb
@@ -50,6 +50,8 @@
 #         def assignee; end
 #         # @return [String, nil]
 #         def html_notes; end
+#         # @return [Array<Hash{String => Hash{String => String}}>]
+#         def memberships; end
 #         class << self
 #           # @return [Asana::Resources::Task]
 #           def create(client, assignee:, workspace:, name:); end

--- a/lib/checkoff/internal/task_hashes.rb
+++ b/lib/checkoff/internal/task_hashes.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module Checkoff
+  module Internal
+    # Builds on the standard API representation of an Asana task with some
+    # convenience keys.
+    class TaskHashes
+      # @param task [Asana::Resources::Task]
+      # @return [Hash]
+      def task_to_h(task)
+        # @type [Hash]
+        task_hash = task.to_h
+        task_hash['unwrapped'] = {}
+        unwrap_custom_fields(task_hash)
+        unwrap_memberships(task_hash)
+        task_hash['task'] = task.name
+        task_hash
+      end
+
+      private
+
+      # @param task_hash [Hash]
+      # @return [void]
+      def unwrap_custom_fields(task_hash)
+        unwrapped_custom_fields = task_hash.fetch('custom_fields', []).group_by do |cf|
+          cf['name']
+        end.transform_values(&:first)
+        task_hash['unwrapped']['custom_fields'] = unwrapped_custom_fields
+      end
+
+      # @param task_hash [Hash]
+      # @param resource [String]
+      # @param key [String]
+      #
+      # @return [void]
+      def unwrap_membership(task_hash, resource, key)
+        # @sg-ignore
+        # @type [Array<Hash>]
+        memberships = task_hash.fetch('memberships', [])
+        # @sg-ignore
+        # @type [Hash]
+        unwrapped = task_hash.fetch('unwrapped')
+        unwrapped["membership_by_#{resource}_#{key}"] = memberships.group_by do |membership|
+          membership[resource][key]
+        end.transform_values(&:first)
+      end
+
+      # @param task_hash [Hash]
+      # @return [void]
+      def unwrap_memberships(task_hash)
+        unwrap_membership(task_hash, 'section', 'gid')
+        unwrap_membership(task_hash, 'project', 'gid')
+        unwrap_membership(task_hash, 'project', 'name')
+      end
+    end
+  end
+end

--- a/lib/checkoff/tasks.rb
+++ b/lib/checkoff/tasks.rb
@@ -6,6 +6,7 @@ require_relative 'sections'
 require_relative 'workspaces'
 require_relative 'internal/config_loader'
 require_relative 'internal/task_timing'
+require_relative 'internal/task_hashes'
 require 'asana'
 
 module Checkoff
@@ -145,11 +146,33 @@ module Checkoff
       end
     end
 
+    # Builds on the standard API representation of an Asana task with some
+    # convenience keys:
+    #
+    # <regular keys from API response>
+    # +
+    # unwrapped:
+    #  membership_by_section_gid: Hash<String, Hash (membership)>
+    #  membership_by_project_gid: Hash<String, Hash (membership)>
+    #  membership_by_project_name: Hash<String, Hash (membership)>
+    # task: String (name)
+    #
+    # @param task [Asana::Resources::Task]
+    # @return [Hash]
+    def task_to_h(task)
+      task_hashes.task_to_h(task)
+    end
+
     private
 
     # @return [Checkoff::Internal::TaskTiming]
     def task_timing
       @task_timing ||= Checkoff::Internal::TaskTiming.new(time_class: @time_class)
+    end
+
+    # @return [Checkoff::Internal::TaskHashes]
+    def task_hashes
+      @task_hashes ||= Checkoff::Internal::TaskHashes.new
     end
 
     # @param workspace_name [String]

--- a/test/unit/internal/test_task_hashes.rb
+++ b/test/unit/internal/test_task_hashes.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+require_relative '../class_test'
+require 'checkoff/internal/task_hashes'
+
+class TestTaskHashes < ClassTest
+  let_mock :task
+
+  MEMBER_OF_SECTION_A_IN_PROJECT_1 = {
+    'section' => {
+      'gid' => 'section_a_gid',
+    },
+    'project' => {
+      'gid' => 'project_1_gid',
+      'name' => 'project_1_name',
+    },
+  }.freeze
+
+  TASK_A_RAW_HASH = {
+    'name' => 'a',
+    'custom_fields' => [
+      {
+        'name' => 'custom_field_x',
+        'display_value' => 'foo',
+      },
+    ],
+    'memberships' => [
+      MEMBER_OF_SECTION_A_IN_PROJECT_1,
+    ],
+  }.freeze
+
+  TASK_A_HASH = {
+    'name' => 'a',
+    'task' => 'a',
+    'custom_fields' => [
+      { 'name' => 'custom_field_x', 'display_value' => 'foo' },
+    ],
+    'memberships' => [
+      MEMBER_OF_SECTION_A_IN_PROJECT_1,
+    ],
+    'unwrapped' => {
+      'custom_fields' => {
+        'custom_field_x' => {
+          'name' => 'custom_field_x',
+          'display_value' => 'foo',
+        },
+      },
+      'membership_by_section_gid' => {
+        'section_a_gid' => MEMBER_OF_SECTION_A_IN_PROJECT_1,
+      },
+      'membership_by_project_gid' => {
+        'project_1_gid' => MEMBER_OF_SECTION_A_IN_PROJECT_1,
+      },
+      'membership_by_project_name' => {
+        'project_1_name' => MEMBER_OF_SECTION_A_IN_PROJECT_1,
+      },
+    },
+  }.freeze
+
+  TASK_B_RAW_HASH = {
+    'name' => 'b',
+    'custom_fields' => [
+      {
+        'name' => 'custom_field_x',
+        'display_value' => 'bar',
+      },
+    ],
+  }.freeze
+
+  TASK_B_HASH = {
+    'name' => 'b',
+    'task' => 'b',
+    'custom_fields' => [
+      { 'name' => 'custom_field_x', 'display_value' => 'bar' },
+    ],
+    'unwrapped' => {
+      'custom_fields' => {
+        'custom_field_x' => { 'name' => 'custom_field_x', 'display_value' => 'bar' },
+      },
+      'membership_by_section_gid' => {},
+      'membership_by_project_gid' => {},
+      'membership_by_project_name' => {},
+    },
+  }.freeze
+
+  def test_task_a_to_h
+    task_hashes = get_test_object do
+      task.expects(:to_h).returns(TASK_A_RAW_HASH.dup)
+      task.expects(:name).returns('a')
+    end
+
+    assert_equal(TASK_A_HASH, task_hashes.task_to_h(task))
+  end
+
+  def test_task_b_to_h
+    task_hashes = get_test_object do
+      task.expects(:to_h).returns(TASK_B_RAW_HASH.dup)
+      task.expects(:name).returns('b')
+    end
+
+    assert_equal(TASK_B_HASH, task_hashes.task_to_h(task))
+  end
+
+  def class_under_test
+    Checkoff::Internal::TaskHashes
+  end
+end

--- a/test/unit/test_tasks.rb
+++ b/test/unit/test_tasks.rb
@@ -11,7 +11,7 @@ class TestTasks < BaseAsana
   def_delegators :@mocks, :sections, :asana_task, :time_class, :client
 
   let_mock :mock_tasks, :modified_mock_tasks, :tasks_by_section,
-           :unflattened_modified_mock_tasks
+           :unflattened_modified_mock_tasks, :task_hashes
 
   let_mock :workspace_gid, :task_name, :default_assignee_gid
 
@@ -263,6 +263,14 @@ class TestTasks < BaseAsana
                                only_uncompleted: only_uncompleted)
 
     assert_equal(task, returned_task)
+  end
+
+  def test_task_to_h_delegates
+    tasks = get_test_object do
+      Checkoff::Internal::TaskHashes.expects(:new).returns(task_hashes)
+      task_hashes.expects(:task_to_h).with(task).returns(123)
+    end
+    assert_equal(123, tasks.task_to_h(task))
   end
 
   def class_under_test


### PR DESCRIPTION
Builds on the standard API representation of an Asana task with some
convenience keys.