### PR TITLE
Retire more task selectors

### DIFF
--- a/lib/checkoff/internal/ready_between_relative.rb
+++ b/lib/checkoff/internal/ready_between_relative.rb
@@ -5,14 +5,14 @@ module Checkoff
     # Determine whether a task is due within a relative date range
     class ReadyBetweenRelative
       # @param config [Hash<Symbol, Object>]
-      # @param clients [Checkoff::Clients]
+      # @param client [Asana::Client]
       # @param task_timing [Checkoff::Internal::TaskTiming]
       # @param tasks [Checkoff::Tasks]
       def initialize(config: Checkoff::Internal::ConfigLoader.load(:asana),
-                     clients: Checkoff::Clients.new(config: config),
-                     task_timing: ::Checkoff::Internal::TaskTiming.new,
+                     client: Checkoff::Clients.new(config: config).client,
+                     task_timing: ::Checkoff::Internal::TaskTiming.new(client: client),
                      tasks: ::Checkoff::Tasks.new(config: config,
-                                                  client: clients.client))
+                                                  client: client))
         @task_timing = task_timing
         @tasks = tasks
       end

--- a/lib/checkoff/internal/selector_classes/task.rb
+++ b/lib/checkoff/internal/selector_classes/task.rb
@@ -166,70 +166,11 @@ module Checkoff
         #
         # @return [Boolean]
         def evaluate(task, beginning_num_days_from_now, end_num_days_from_now, ignore_dependencies: false)
-          ready_between_relative = Checkoff::Internal::ReadyBetweenRelative.new(tasks: @tasks)
+          ready_between_relative = Checkoff::Internal::ReadyBetweenRelative.new(tasks: @tasks,
+                                                                                client: @client)
           ready_between_relative.ready_between_relative?(task,
                                                          beginning_num_days_from_now, end_num_days_from_now,
                                                          ignore_dependencies: ignore_dependencies)
-        end
-      end
-
-      # :custom_field_less_than_n_days_from_now function
-      class CustomFieldLessThanNDaysFromNowFunctionEvaluator < FunctionEvaluator
-        FUNCTION_NAME = :custom_field_less_than_n_days_from_now
-
-        def matches?
-          fn?(selector, FUNCTION_NAME)
-        end
-
-        def evaluate_arg?(_index)
-          false
-        end
-
-        # @param task [Asana::Resources::Task]
-        # @param custom_field_name [String]
-        # @param num_days [Integer]
-        # @return [Boolean]
-        def evaluate(task, custom_field_name, num_days)
-          custom_field = @custom_fields.resource_custom_field_by_name_or_raise(task, custom_field_name)
-
-          # @sg-ignore
-          # @type [String, nil]
-          time_str = custom_field.fetch('display_value')
-          return false if time_str.nil?
-
-          time = Time.parse(time_str)
-          n_days_from_now = (Time.now + (num_days * 24 * 60 * 60))
-          time < n_days_from_now
-        end
-      end
-
-      # :custom_field_greater_than_or_equal_to_n_days_from_now function
-      class CustomFieldGreaterThanOrEqualToNDaysFromNowFunctionEvaluator < FunctionEvaluator
-        FUNCTION_NAME = :custom_field_greater_than_or_equal_to_n_days_from_now
-
-        def matches?
-          fn?(selector, FUNCTION_NAME)
-        end
-
-        def evaluate_arg?(_index)
-          false
-        end
-
-        # @param task [Asana::Resources::Task]
-        # @param custom_field_name [String]
-        # @param num_days [Integer]
-        # @return [Boolean]
-        def evaluate(task, custom_field_name, num_days)
-          custom_field = @custom_fields.resource_custom_field_by_name_or_raise(task, custom_field_name)
-
-          # @sg-ignore
-          # @type [String, nil]
-          time_str = custom_field.fetch('display_value')
-          return false if time_str.nil?
-
-          time = Time.parse(time_str)
-          n_days_from_now = (Time.now + (num_days * 24 * 60 * 60))
-          time >= n_days_from_now
         end
       end
 

--- a/lib/checkoff/tasks.rb
+++ b/lib/checkoff/tasks.rb
@@ -28,6 +28,7 @@ module Checkoff
     # @param workspaces [Checkoff::Workspaces]
     # @param sections [Checkoff::Sections]
     # @param portfolios [Checkoff::Portfolios]
+    # @param custom_fields [Checkoff::CustomFields]
     # @param time_class [Class<Time>]
     # @param date_class [Class<Date>]
     # @param asana_task [Class<Asana::Resources::Task>]
@@ -39,6 +40,8 @@ module Checkoff
                                                     client: client),
                    portfolios: Checkoff::Portfolios.new(config: config,
                                                         client: client),
+                   custom_fields: Checkoff::CustomFields.new(config: config,
+                                                             client: client),
                    time_class: Time,
                    date_class: Date,
                    asana_task: Asana::Resources::Task)
@@ -49,6 +52,7 @@ module Checkoff
       @asana_task = asana_task
       @client = client
       @portfolios = portfolios
+      @custom_fields = custom_fields
       @workspaces = workspaces
       @timing = Timing.new(today_getter: date_class, now_getter: time_class)
     end
@@ -73,7 +77,7 @@ module Checkoff
     end
 
     # @param task [Asana::Resources::Task]
-    # @param field_name [Symbol]
+    # @param field_name [Symbol,Array]
     # @param period [Symbol<:now_or_before,:this_week>,Array] See Checkoff::Timing#in_period?_
     def in_period?(task, field_name, period)
       # @type [Date,Time,nil]
@@ -210,7 +214,9 @@ module Checkoff
 
     # @return [Checkoff::Internal::TaskTiming]
     def task_timing
-      @task_timing ||= Checkoff::Internal::TaskTiming.new(time_class: @time_class, date_class: @date_class)
+      @task_timing ||= Checkoff::Internal::TaskTiming.new(time_class: @time_class, date_class: @date_class,
+                                                          client: client,
+                                                          custom_fields: custom_fields)
     end
 
     # @return [Checkoff::Internal::TaskHashes]
@@ -245,6 +251,9 @@ module Checkoff
 
     # @return [Checkoff::Timing]
     attr_reader :timing
+
+    # @return [Checkoff::CustomFields]
+    attr_reader :custom_fields
 
     # @return [Checkoff::Projects]
     def projects

--- a/lib/checkoff/timing.rb
+++ b/lib/checkoff/timing.rb
@@ -70,6 +70,15 @@ module Checkoff
 
     # @param date_or_time [Date,Time,nil]
     # @param num_days [Integer]
+    def greater_than_or_equal_to_n_days_from_now?(date_or_time, num_days)
+      return false if date_or_time.nil?
+
+      n_days_from_now = (@now_getter.now + (num_days * 24 * 60 * 60))
+      date_or_time >= n_days_from_now
+    end
+
+    # @param date_or_time [Date,Time,nil]
+    # @param num_days [Integer]
     def less_than_n_days_ago?(date_or_time, num_days)
       return false if date_or_time.nil?
 
@@ -79,6 +88,15 @@ module Checkoff
       n_days_ago = @today_getter.today - num_days
       # @sg-ignore
       date < n_days_ago
+    end
+
+    # @param date_or_time [Date,Time,nil]
+    # @param num_days [Integer]
+    def less_than_n_days_from_now?(date_or_time, num_days)
+      return false if date_or_time.nil?
+
+      n_days_from_now = (@now_getter.now + (num_days * 24 * 60 * 60))
+      date_or_time < n_days_from_now
     end
 
     # @param date_or_time [Date,Time,nil]
@@ -112,10 +130,17 @@ module Checkoff
       # @sg-ignore
       return less_than_n_days_ago?(date_or_time, *args) if period_name == :less_than_n_days_ago
 
-      if period_name == :greater_than_or_equal_to_n_days_from_today
-        return greater_than_or_equal_to_n_days_from_today?(date_or_time,
-                                                           *args)
+      return less_than_n_days_from_now?(date_or_time, *args) if period_name == :less_than_n_days_from_now
+
+      if period_name == :greater_than_or_equal_to_n_days_from_now
+        return greater_than_or_equal_to_n_days_from_now?(date_or_time,
+                                                         *args)
       end
+
+      if period_name == :greater_than_or_equal_to_n_days_from_today
+        return greater_than_or_equal_to_n_days_from_today?(date_or_time, *args)
+      end
+
       raise "Teach me how to handle period [#{period_name.inspect}, #{args.join(', ')}]"
     end
 

--- a/test/unit/internal/test_task_timing.rb
+++ b/test/unit/internal/test_task_timing.rb
@@ -18,7 +18,10 @@ class TestTaskTiming < ClassTest
   end
 
   def respond_like_instance_of
-    {}
+    {
+      client: Asana::Client,
+      custom_fields: Checkoff::CustomFields,
+    }
   end
 
   def respond_like


### PR DESCRIPTION
:custom_field_less_than_n_days_from_now and
:custom_field_greater_than_or_equal_to_n_days_from_now are replaced by
use of :in_period?