### PR TITLE
Add .dir-locals.el in test/unit to disable lsp-mode

### DIFF
--- a/test/unit/.dir-locals.el
+++ b/test/unit/.dir-locals.el
@@ -1,0 +1,1 @@
+((nil . ((eval . (setq-local flycheck-disabled-checkers '(lsp))))))


### PR DESCRIPTION
...otherwise Solargraph tries to handle unit tests with mocks, which
is beyond its capabilities.