### PR TITLE
Fix gem release shipping stale test/ types in sig/checkoff.rbs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,6 +58,9 @@ commands:
           keys:
             - ruby-types-v8-{{ checksum "checkoff.gemspec" }}-{{ checksum "Gemfile" }}-{{ checksum "Gemfile.lock" }}-{{ checksum "rbs_collection.lock.yaml" }}-{{ checksum "Makefile" }}-{{ checksum ".circleci/config.yml" }}- # yamllint disable-line rule:line-length
             - ruby-types-v8-{{ checksum "checkoff.gemspec" }}-{{ checksum "Gemfile" }}-{{ checksum "Gemfile.lock" }}-{{ checksum "Makefile" }}- # yamllint disable-line rule:line-length
+            - ruby-types-v8-{{ checksum "checkoff.gemspec" }}-{{ checksum "Gemfile" }}-{{ checksum "Gemfile.lock" }}- # yamllint disable-line rule:line-length
+            - ruby-types-v8-{{ checksum "checkoff.gemspec" }}-{{ checksum "Gemfile" }}-
+            - ruby-types-v8-{{ checksum "checkoff.gemspec" }}-
             - ruby-types-v8-
       - restore_cache:
           name: Restore pyenv cache
@@ -245,10 +248,14 @@ jobs:
           name: 'Save ruby-types cache'
           key: ruby-types-v8-{{ checksum "checkoff.gemspec" }}-{{ checksum "Gemfile" }}-{{ checksum "Gemfile.lock" }}-{{ checksum "rbs_collection.lock.yaml" }}-{{ checksum "Makefile" }}-{{ checksum ".circleci/config.yml" }}-{{ checksum ".ruby-version" }}-{{ checksum "rbi/checkoff.rbi" }}  # yamllint disable-line rule:line-length
           paths:
+            - ".yardoc"
+            - "yardoc"
             - "/home/circleci/.cache/solargraph"
             - "/home/circleci/.sorbet-cache"
             - "/home/circleci/.cache/sorbet"
             - "types.installed"
+            - "yardoc.installed"
+            - ".yard-deps.sha256"
             - "tapioca.installed"
             - "sorbet/machine_specific_config"
             - "rbi/checkoff.rbi"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,12 +56,9 @@ commands:
       - restore_cache:
           name: Restore ruby-types cache
           keys:
-            - ruby-types-v7-{{ checksum "checkoff.gemspec" }}-{{ checksum "Gemfile" }}-{{ checksum "Gemfile.lock" }}-{{ checksum "rbs_collection.lock.yaml" }}-{{ checksum "Makefile" }}-{{ checksum ".circleci/config.yml" }}- # yamllint disable-line rule:line-length
-            - ruby-types-v7-{{ checksum "checkoff.gemspec" }}-{{ checksum "Gemfile" }}-{{ checksum "Gemfile.lock" }}-{{ checksum "Makefile" }}- # yamllint disable-line rule:line-length
-            - ruby-types-v7-{{ checksum "checkoff.gemspec" }}-{{ checksum "Gemfile" }}-{{ checksum "Gemfile.lock" }}- # yamllint disable-line rule:line-length
-            - ruby-types-v7-{{ checksum "checkoff.gemspec" }}-{{ checksum "Gemfile" }}-
-            - ruby-types-v7-{{ checksum "checkoff.gemspec" }}-
-            - ruby-types-v7-
+            - ruby-types-v8-{{ checksum "checkoff.gemspec" }}-{{ checksum "Gemfile" }}-{{ checksum "Gemfile.lock" }}-{{ checksum "rbs_collection.lock.yaml" }}-{{ checksum "Makefile" }}-{{ checksum ".circleci/config.yml" }}- # yamllint disable-line rule:line-length
+            - ruby-types-v8-{{ checksum "checkoff.gemspec" }}-{{ checksum "Gemfile" }}-{{ checksum "Gemfile.lock" }}-{{ checksum "Makefile" }}- # yamllint disable-line rule:line-length
+            - ruby-types-v8-
       - restore_cache:
           name: Restore pyenv cache
           keys:
@@ -246,15 +243,12 @@ jobs:
           path: rbi/checkoff.rbi
       - save_cache:
           name: 'Save ruby-types cache'
-          key: ruby-types-v7-{{ checksum "checkoff.gemspec" }}-{{ checksum "Gemfile" }}-{{ checksum "Gemfile.lock" }}-{{ checksum "rbs_collection.lock.yaml" }}-{{ checksum "Makefile" }}-{{ checksum ".circleci/config.yml" }}-{{ checksum ".ruby-version" }}-{{ checksum "rbi/checkoff.rbi" }}  # yamllint disable-line rule:line-length
+          key: ruby-types-v8-{{ checksum "checkoff.gemspec" }}-{{ checksum "Gemfile" }}-{{ checksum "Gemfile.lock" }}-{{ checksum "rbs_collection.lock.yaml" }}-{{ checksum "Makefile" }}-{{ checksum ".circleci/config.yml" }}-{{ checksum ".ruby-version" }}-{{ checksum "rbi/checkoff.rbi" }}  # yamllint disable-line rule:line-length
           paths:
-            - ".yardoc"
-            - "yardoc"
             - "/home/circleci/.cache/solargraph"
             - "/home/circleci/.sorbet-cache"
             - "/home/circleci/.cache/sorbet"
             - "types.installed"
-            - "yardoc.installed"
             - "tapioca.installed"
             - "sorbet/machine_specific_config"
             - "rbi/checkoff.rbi"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,12 +56,25 @@ commands:
       - restore_cache:
           name: Restore ruby-types cache
           keys:
-            - ruby-types-v8-{{ checksum "checkoff.gemspec" }}-{{ checksum "Gemfile" }}-{{ checksum "Gemfile.lock" }}-{{ checksum "rbs_collection.lock.yaml" }}-{{ checksum "Makefile" }}-{{ checksum ".circleci/config.yml" }}- # yamllint disable-line rule:line-length
-            - ruby-types-v8-{{ checksum "checkoff.gemspec" }}-{{ checksum "Gemfile" }}-{{ checksum "Gemfile.lock" }}-{{ checksum "Makefile" }}- # yamllint disable-line rule:line-length
-            - ruby-types-v8-{{ checksum "checkoff.gemspec" }}-{{ checksum "Gemfile" }}-{{ checksum "Gemfile.lock" }}- # yamllint disable-line rule:line-length
-            - ruby-types-v8-{{ checksum "checkoff.gemspec" }}-{{ checksum "Gemfile" }}-
-            - ruby-types-v8-{{ checksum "checkoff.gemspec" }}-
-            - ruby-types-v8-
+            - ruby-types-v9-{{ checksum "checkoff.gemspec" }}-{{ checksum "Gemfile" }}-{{ checksum "Gemfile.lock" }}-{{ checksum "rbs_collection.lock.yaml" }}-{{ checksum "Makefile" }}-{{ checksum ".circleci/config.yml" }}- # yamllint disable-line rule:line-length
+            - ruby-types-v9-{{ checksum "checkoff.gemspec" }}-{{ checksum "Gemfile" }}-{{ checksum "Gemfile.lock" }}-{{ checksum "Makefile" }}- # yamllint disable-line rule:line-length
+      - run:
+          name: Normalize ruby-types cache stamp mtimes
+          command: |
+            # Cache restore runs after git timestamp normalization; align stamp
+            # files so make compares them with the same clock as sources.
+            if [ -f yardoc.installed ]; then
+              unixtime=$(git log -1 --format="%at" -- Makefile)
+              touchtime=$(date -d @$unixtime +'%Y%m%d%H%M.%S')
+              touch -ht ${touchtime} yardoc.installed
+            fi
+            for stamp in types.installed tapioca.installed; do
+              if [ -f "${stamp}" ]; then
+                unixtime=$(git log -1 --format="%at")
+                touchtime=$(date -d @$unixtime +'%Y%m%d%H%M.%S')
+                touch -ht ${touchtime} "${stamp}"
+              fi
+            done
       - restore_cache:
           name: Restore pyenv cache
           keys:
@@ -246,7 +259,7 @@ jobs:
           path: rbi/checkoff.rbi
       - save_cache:
           name: 'Save ruby-types cache'
-          key: ruby-types-v8-{{ checksum "checkoff.gemspec" }}-{{ checksum "Gemfile" }}-{{ checksum "Gemfile.lock" }}-{{ checksum "rbs_collection.lock.yaml" }}-{{ checksum "Makefile" }}-{{ checksum ".circleci/config.yml" }}-{{ checksum ".ruby-version" }}-{{ checksum "rbi/checkoff.rbi" }}  # yamllint disable-line rule:line-length
+          key: ruby-types-v9-{{ checksum "checkoff.gemspec" }}-{{ checksum "Gemfile" }}-{{ checksum "Gemfile.lock" }}-{{ checksum "rbs_collection.lock.yaml" }}-{{ checksum "Makefile" }}-{{ checksum ".circleci/config.yml" }}-{{ checksum ".ruby-version" }}-{{ checksum "rbi/checkoff.rbi" }}  # yamllint disable-line rule:line-length
           paths:
             - ".yardoc"
             - "yardoc"
@@ -255,7 +268,6 @@ jobs:
             - "/home/circleci/.cache/sorbet"
             - "types.installed"
             - "yardoc.installed"
-            - ".yard-deps.sha256"
             - "tapioca.installed"
             - "sorbet/machine_specific_config"
             - "rbi/checkoff.rbi"

--- a/.gitignore
+++ b/.gitignore
@@ -44,7 +44,6 @@ requirements_dev.txt.installed
 types.installed
 tapioca.installed
 yardoc.installed
-.yard-deps.sha256
 
 # Type checking config
 sorbet/machine_specific_config

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ requirements_dev.txt.installed
 types.installed
 tapioca.installed
 yardoc.installed
+.yard-deps.sha256
 
 # Type checking config
 sorbet/machine_specific_config

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-typecheck bundle_install cicoverage citypecheck citest citypecoverage clean clean-coverage clean-typecheck clean-typecoverage coverage default docs gem_dependencies help overcommit quality repl report-coverage rubocop rubocop-ratchet test typecheck typecoverage update_from_cookiecutter yard
+.PHONY: build build-typecheck bundle_install cicoverage citypecheck citest citypecoverage ci-verify-gem-rbs clean clean-coverage clean-typecheck clean-typecoverage coverage default docs gem_dependencies help overcommit quality repl report-coverage release-types rubocop rubocop-ratchet test typecheck typecoverage update_from_cookiecutter verify-gem-rbs yard
 
 .DEFAULT_GOAL := default
 
@@ -50,11 +50,6 @@ types.installed: tapioca.installed Gemfile.lock Gemfile.lock.installed rbi/check
 	bin/yard gems $(YARD_PLUGIN_OPTS) 2>&1 || bin/yard gems --safe $(YARD_PLUGIN_OPTS) 2>&1 || bin/yard gems $(YARD_PLUGIN_OPTS) 2>&1
 	# bin/solargraph scan 2>&1
 	bin/spoom srb bump || true
-	# spoom rudely updates timestamps on files, so let's keep up by
-	# touching yardoc.installed so we dont' end up in a vicious
-	# cycle
-	touch yardoc.installed rbi/checkoff.rbi
-	# bin/solargraph scan 2>&1
 	touch types.installed
 
 build: bundle_install pip_install build-typecheck ## Update 3rd party packages as well and produce any artifacts needed from code
@@ -139,10 +134,18 @@ solargraph-strong: build-typecheck ## Run Solargraph typechecker
 
 typecheck: build-typecheck srb solargraph  ## validate types in code and configuration
 
-citypecheck: ci-build-typecheck srb ci-solargraph ## Run type check from CircleCI
+citypecheck: ci-build-typecheck srb ci-solargraph ci-verify-gem-rbs ## Run type check from CircleCI
 
 ci-solargraph: ## Run Solargraph typechecker in CI
 	  bin/solargraph typecheck --level strong
+
+ci-verify-gem-rbs: clean-typecheck sig/checkoff.rbs verify-gem-rbs ## Regenerate gem RBS from clean YARD and reject test/ types
+
+verify-gem-rbs: sig/checkoff.rbs ## Fail if published RBS would include test-only types
+	@if grep -E '^(class Test|module TestDate)' sig/checkoff.rbs; then \
+	  echo 'error: test/ types in sig/checkoff.rbs (stale .yardoc or YARD exclude)'; \
+	  exit 1; \
+	fi
 
 typecoverage: typecheck ## Run type checking and then ratchet coverage in metrics/
 
@@ -220,7 +223,9 @@ clean-coverage: clear_metrics ## Clean out previous output of test coverage to a
 coverage: test report-coverage ## check code coverage
 	@bin/rake undercover
 
-release: sig/checkoff.rbs rbi/checkoff.rbi ## Create a new release
+release-types: clean-typecheck build-typecheck sig/checkoff.rbs verify-gem-rbs ## Fresh RBI/RBS artifacts for gem release
+
+release: release-types ## Create a new release
 	bin/rake release
 
 report-coverage: test ## Report summary of coverage to stdout, and generate HTML, XML coverage report

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: _yard-docs-sync build build-typecheck bundle_install cicoverage citypecheck citest citypecoverage clean clean-coverage clean-typecheck clean-typecoverage coverage default docs gem_dependencies help overcommit quality repl report-coverage rubocop rubocop-ratchet test typecheck typecoverage update_from_cookiecutter verify-gem-rbs yard
+.PHONY: build build-typecheck bundle_install cicoverage citypecheck citest citypecoverage clean clean-coverage clean-typecheck clean-typecoverage coverage default docs gem_dependencies help overcommit quality repl report-coverage rubocop rubocop-ratchet test typecheck typecoverage update_from_cookiecutter verify-gem-rbs yard
 
 .DEFAULT_GOAL := default
 
@@ -21,10 +21,6 @@ default: clean-typecoverage build typecheck typecoverage clean-coverage test cov
 SOURCE_FILE_GLOBS = ['{config,lib,app,script,spec,feature}/**/*.rb', 'ext/**/*.{c,rb}']
 
 SOURCE_FILES := $(shell ruby -e "puts Dir.glob($(SOURCE_FILE_GLOBS))")
-
-YARD_SOURCE_FILE_GLOBS = ['{lib,app}/**/*.rb', 'ext/**/*.{c,rb}']
-
-YARD_DEPS_STAMP = .yard-deps.sha256
 
 start: ## run code continously and watch files for changes
 	echo "Teach me how to 'make start'"
@@ -93,29 +89,10 @@ tapioca.installed: sorbet/tapioca/require.rb Gemfile.lock.installed ## Install T
 #	bin/tapioca dsl
 	touch tapioca.installed
 
-.PHONY: _yard-docs-sync
-_yard-docs-sync:
-	@current=$$(YARD_OPTS='$(YARD_OPTS)' YARD_SOURCE_FILE_GLOBS='$(YARD_SOURCE_FILE_GLOBS)' ruby -r digest -e ' \
-	  require "digest"; \
-	  globs = eval(ENV.fetch("YARD_SOURCE_FILE_GLOBS")); \
-	  h = Digest::SHA256.new; \
-	  h << File.read("Makefile"); \
-	  h << ENV.fetch("YARD_OPTS"); \
-	  globs.each { |g| Dir.glob(g).sort.each { |f| h << f << File.read(f) } }; \
-	  puts h.hexdigest \
-	'); \
-	if [ -f yardoc.installed ] && [ -f $(YARD_DEPS_STAMP) ] && [ -d .yardoc ] && \
-	   [ "$$current" = "$$(cat $(YARD_DEPS_STAMP))" ]; then \
-	  :; \
-	else \
-	  rm -rf .yardoc; \
-	  bin/yard doc $(YARD_OPTS); \
-	  echo "$$current" > $(YARD_DEPS_STAMP); \
-	  touch yardoc.installed; \
-	fi
-
-yardoc.installed: _yard-docs-sync ## Generate YARD documentation
-	@test -f yardoc.installed || touch yardoc.installed
+yardoc.installed: Makefile $(SOURCE_FILES) ## Generate YARD documentation
+	@if [ Makefile -nt yardoc.installed ]; then rm -rf .yardoc; fi
+	bin/yard doc $(YARD_OPTS)
+	touch yardoc.installed
 
 yard: yardoc.installed ## Generate YARD documentation
 
@@ -123,7 +100,7 @@ docs: ## Generate YARD documentation
 	@rake doc
 
 clean-typecheck: ## Refresh the easily-regenerated information that type checking depends on
-	rm -fr .yardoc/ rbi/checkoff.rbi types.installed yardoc.installed $(YARD_DEPS_STAMP) sig/checkoff.rbs || true
+	rm -fr .yardoc/ rbi/checkoff.rbi types.installed yardoc.installed sig/checkoff.rbs || true
 	echo all clear
 
 realclean-typecheck: clean-typecheck ## Remove all type checking artifacts

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-typecheck bundle_install cicoverage citypecheck citest citypecoverage ci-verify-gem-rbs clean clean-coverage clean-typecheck clean-typecoverage coverage default docs gem_dependencies help overcommit quality repl report-coverage release-types rubocop rubocop-ratchet test typecheck typecoverage update_from_cookiecutter verify-gem-rbs yard
+.PHONY: _yard-docs-sync build build-typecheck bundle_install cicoverage citypecheck citest citypecoverage clean clean-coverage clean-typecheck clean-typecoverage coverage default docs gem_dependencies help overcommit quality repl report-coverage rubocop rubocop-ratchet test typecheck typecoverage update_from_cookiecutter verify-gem-rbs yard
 
 .DEFAULT_GOAL := default
 
@@ -21,6 +21,10 @@ default: clean-typecoverage build typecheck typecoverage clean-coverage test cov
 SOURCE_FILE_GLOBS = ['{config,lib,app,script,spec,feature}/**/*.rb', 'ext/**/*.{c,rb}']
 
 SOURCE_FILES := $(shell ruby -e "puts Dir.glob($(SOURCE_FILE_GLOBS))")
+
+YARD_SOURCE_FILE_GLOBS = ['{lib,app}/**/*.rb', 'ext/**/*.{c,rb}']
+
+YARD_DEPS_STAMP = .yard-deps.sha256
 
 start: ## run code continously and watch files for changes
 	echo "Teach me how to 'make start'"
@@ -89,9 +93,29 @@ tapioca.installed: sorbet/tapioca/require.rb Gemfile.lock.installed ## Install T
 #	bin/tapioca dsl
 	touch tapioca.installed
 
-yardoc.installed: Makefile $(SOURCE_FILES) ## Generate YARD documentation
-	bin/yard doc $(YARD_OPTS)
-	touch yardoc.installed
+.PHONY: _yard-docs-sync
+_yard-docs-sync:
+	@current=$$(YARD_OPTS='$(YARD_OPTS)' YARD_SOURCE_FILE_GLOBS='$(YARD_SOURCE_FILE_GLOBS)' ruby -r digest -e ' \
+	  require "digest"; \
+	  globs = eval(ENV.fetch("YARD_SOURCE_FILE_GLOBS")); \
+	  h = Digest::SHA256.new; \
+	  h << File.read("Makefile"); \
+	  h << ENV.fetch("YARD_OPTS"); \
+	  globs.each { |g| Dir.glob(g).sort.each { |f| h << f << File.read(f) } }; \
+	  puts h.hexdigest \
+	'); \
+	if [ -f yardoc.installed ] && [ -f $(YARD_DEPS_STAMP) ] && [ -d .yardoc ] && \
+	   [ "$$current" = "$$(cat $(YARD_DEPS_STAMP))" ]; then \
+	  :; \
+	else \
+	  rm -rf .yardoc; \
+	  bin/yard doc $(YARD_OPTS); \
+	  echo "$$current" > $(YARD_DEPS_STAMP); \
+	  touch yardoc.installed; \
+	fi
+
+yardoc.installed: _yard-docs-sync ## Generate YARD documentation
+	@test -f yardoc.installed || touch yardoc.installed
 
 yard: yardoc.installed ## Generate YARD documentation
 
@@ -99,7 +123,7 @@ docs: ## Generate YARD documentation
 	@rake doc
 
 clean-typecheck: ## Refresh the easily-regenerated information that type checking depends on
-	rm -fr .yardoc/ rbi/checkoff.rbi types.installed yardoc.installed sig/checkoff.rbs || true
+	rm -fr .yardoc/ rbi/checkoff.rbi types.installed yardoc.installed $(YARD_DEPS_STAMP) sig/checkoff.rbs || true
 	echo all clear
 
 realclean-typecheck: clean-typecheck ## Remove all type checking artifacts
@@ -134,12 +158,10 @@ solargraph-strong: build-typecheck ## Run Solargraph typechecker
 
 typecheck: build-typecheck srb solargraph  ## validate types in code and configuration
 
-citypecheck: ci-build-typecheck srb ci-solargraph ci-verify-gem-rbs ## Run type check from CircleCI
+citypecheck: ci-build-typecheck srb ci-solargraph verify-gem-rbs ## Run type check from CircleCI
 
 ci-solargraph: ## Run Solargraph typechecker in CI
 	  bin/solargraph typecheck --level strong
-
-ci-verify-gem-rbs: clean-typecheck sig/checkoff.rbs verify-gem-rbs ## Regenerate gem RBS from clean YARD and reject test/ types
 
 verify-gem-rbs: sig/checkoff.rbs ## Fail if published RBS would include test-only types
 	@if grep -E '^(class Test|module TestDate)' sig/checkoff.rbs; then \
@@ -223,9 +245,7 @@ clean-coverage: clear_metrics ## Clean out previous output of test coverage to a
 coverage: test report-coverage ## check code coverage
 	@bin/rake undercover
 
-release-types: clean-typecheck build-typecheck sig/checkoff.rbs verify-gem-rbs ## Fresh RBI/RBS artifacts for gem release
-
-release: release-types ## Create a new release
+release: sig/checkoff.rbs verify-gem-rbs ## Create a new release
 	bin/rake release
 
 report-coverage: test ## Report summary of coverage to stdout, and generate HTML, XML coverage report


### PR DESCRIPTION
## Summary

0.249.0 republished stale `sig/checkoff.rbs` because `publish_gem` skipped YARD: restored `yardoc.installed` had wall-clock mtimes while sources were already normalized to commit time, and `types.installed` was touching `yardoc.installed` without running YARD.

- **CircleCI:** after `restore_cache`, normalize `yardoc.installed` (to Makefile commit time) and other type stamps to git commit times — same scheme as the existing checkout step.
- **CircleCI:** drop ruby-types cache fallbacks that omit `Makefile`; bump key to v9.
- **Makefile:** restore normal `yardoc.installed: Makefile $(SOURCE_FILES)` mtime logic; `rm -rf .yardoc` when Makefile is newer than the stamp (YARD_OPTS changes).
- **Makefile:** stop `types.installed` from touching `yardoc.installed` after spoom.
- **`verify-gem-rbs`** in `citypecheck` and `make release` as a safety net.

## Test plan

- [ ] CircleCI build on this PR passes (`verify-gem-rbs` in citypecheck).
- [ ] After merge, `publish_gem` produces a release whose `sig/checkoff.rbs` has no `Test*` / `TestDate` types.
- [ ] plate-spinner-rails can drop `rbs_collection` checkoff ignore after bumping to the new release.