### PR TITLE
Invalidate ruby-types cache prefix when YARD_OPTS change

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,14 +54,16 @@ commands:
             - rbenv-v5-
             - rbenv-
       - restore_cache:
+          # NOTE: bump the ruby-types-vN- prefix when YARD_OPTS changes in
+          # the Makefile (see the comment there for why).
           name: Restore ruby-types cache
           keys:
-            - ruby-types-v7-{{ checksum "checkoff.gemspec" }}-{{ checksum "Gemfile" }}-{{ checksum "Gemfile.lock" }}-{{ checksum "rbs_collection.lock.yaml" }}-{{ checksum "Makefile" }}-{{ checksum ".circleci/config.yml" }}- # yamllint disable-line rule:line-length
-            - ruby-types-v7-{{ checksum "checkoff.gemspec" }}-{{ checksum "Gemfile" }}-{{ checksum "Gemfile.lock" }}-{{ checksum "Makefile" }}- # yamllint disable-line rule:line-length
-            - ruby-types-v7-{{ checksum "checkoff.gemspec" }}-{{ checksum "Gemfile" }}-{{ checksum "Gemfile.lock" }}- # yamllint disable-line rule:line-length
-            - ruby-types-v7-{{ checksum "checkoff.gemspec" }}-{{ checksum "Gemfile" }}-
-            - ruby-types-v7-{{ checksum "checkoff.gemspec" }}-
-            - ruby-types-v7-
+            - ruby-types-v8-{{ checksum "checkoff.gemspec" }}-{{ checksum "Gemfile" }}-{{ checksum "Gemfile.lock" }}-{{ checksum "rbs_collection.lock.yaml" }}-{{ checksum "Makefile" }}-{{ checksum ".circleci/config.yml" }}- # yamllint disable-line rule:line-length
+            - ruby-types-v8-{{ checksum "checkoff.gemspec" }}-{{ checksum "Gemfile" }}-{{ checksum "Gemfile.lock" }}-{{ checksum "Makefile" }}- # yamllint disable-line rule:line-length
+            - ruby-types-v8-{{ checksum "checkoff.gemspec" }}-{{ checksum "Gemfile" }}-{{ checksum "Gemfile.lock" }}- # yamllint disable-line rule:line-length
+            - ruby-types-v8-{{ checksum "checkoff.gemspec" }}-{{ checksum "Gemfile" }}-
+            - ruby-types-v8-{{ checksum "checkoff.gemspec" }}-
+            - ruby-types-v8-
       - restore_cache:
           name: Restore pyenv cache
           keys:
@@ -246,7 +248,7 @@ jobs:
           path: rbi/checkoff.rbi
       - save_cache:
           name: 'Save ruby-types cache'
-          key: ruby-types-v7-{{ checksum "checkoff.gemspec" }}-{{ checksum "Gemfile" }}-{{ checksum "Gemfile.lock" }}-{{ checksum "rbs_collection.lock.yaml" }}-{{ checksum "Makefile" }}-{{ checksum ".circleci/config.yml" }}-{{ checksum ".ruby-version" }}-{{ checksum "rbi/checkoff.rbi" }}  # yamllint disable-line rule:line-length
+          key: ruby-types-v8-{{ checksum "checkoff.gemspec" }}-{{ checksum "Gemfile" }}-{{ checksum "Gemfile.lock" }}-{{ checksum "rbs_collection.lock.yaml" }}-{{ checksum "Makefile" }}-{{ checksum ".circleci/config.yml" }}-{{ checksum ".ruby-version" }}-{{ checksum "rbi/checkoff.rbi" }}  # yamllint disable-line rule:line-length
           paths:
             - ".yardoc"
             - "yardoc"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,12 +58,12 @@ commands:
           # the Makefile (see the comment there for why).
           name: Restore ruby-types cache
           keys:
-            - ruby-types-v8-{{ checksum "checkoff.gemspec" }}-{{ checksum "Gemfile" }}-{{ checksum "Gemfile.lock" }}-{{ checksum "rbs_collection.lock.yaml" }}-{{ checksum "Makefile" }}-{{ checksum ".circleci/config.yml" }}- # yamllint disable-line rule:line-length
-            - ruby-types-v8-{{ checksum "checkoff.gemspec" }}-{{ checksum "Gemfile" }}-{{ checksum "Gemfile.lock" }}-{{ checksum "Makefile" }}- # yamllint disable-line rule:line-length
-            - ruby-types-v8-{{ checksum "checkoff.gemspec" }}-{{ checksum "Gemfile" }}-{{ checksum "Gemfile.lock" }}- # yamllint disable-line rule:line-length
-            - ruby-types-v8-{{ checksum "checkoff.gemspec" }}-{{ checksum "Gemfile" }}-
-            - ruby-types-v8-{{ checksum "checkoff.gemspec" }}-
-            - ruby-types-v8-
+            - ruby-types-v11-{{ checksum "checkoff.gemspec" }}-{{ checksum "Gemfile" }}-{{ checksum "Gemfile.lock" }}-{{ checksum "rbs_collection.lock.yaml" }}-{{ checksum "Makefile" }}-{{ checksum ".circleci/config.yml" }}- # yamllint disable-line rule:line-length
+            - ruby-types-v11-{{ checksum "checkoff.gemspec" }}-{{ checksum "Gemfile" }}-{{ checksum "Gemfile.lock" }}-{{ checksum "Makefile" }}- # yamllint disable-line rule:line-length
+            - ruby-types-v11-{{ checksum "checkoff.gemspec" }}-{{ checksum "Gemfile" }}-{{ checksum "Gemfile.lock" }}- # yamllint disable-line rule:line-length
+            - ruby-types-v11-{{ checksum "checkoff.gemspec" }}-{{ checksum "Gemfile" }}-
+            - ruby-types-v11-{{ checksum "checkoff.gemspec" }}-
+            - ruby-types-v11-
       - restore_cache:
           name: Restore pyenv cache
           keys:
@@ -248,7 +248,7 @@ jobs:
           path: rbi/checkoff.rbi
       - save_cache:
           name: 'Save ruby-types cache'
-          key: ruby-types-v8-{{ checksum "checkoff.gemspec" }}-{{ checksum "Gemfile" }}-{{ checksum "Gemfile.lock" }}-{{ checksum "rbs_collection.lock.yaml" }}-{{ checksum "Makefile" }}-{{ checksum ".circleci/config.yml" }}-{{ checksum ".ruby-version" }}-{{ checksum "rbi/checkoff.rbi" }}  # yamllint disable-line rule:line-length
+          key: ruby-types-v11-{{ checksum "checkoff.gemspec" }}-{{ checksum "Gemfile" }}-{{ checksum "Gemfile.lock" }}-{{ checksum "rbs_collection.lock.yaml" }}-{{ checksum "Makefile" }}-{{ checksum ".circleci/config.yml" }}-{{ checksum ".ruby-version" }}-{{ checksum "rbi/checkoff.rbi" }}  # yamllint disable-line rule:line-length
           paths:
             - ".yardoc"
             - "yardoc"

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,16 @@ sig/checkoff.rbs: yardoc.installed .gem_rbs_collection/.keepme ## Generate RBS f
 
 YARD_PLUGIN_OPTS = --plugin yard-sorbet --plugin yard-solargraph
 
+# IMPORTANT: if you change the source globs/excludes below, bump the
+# ruby-types-vN- cache prefix in .circleci/config.yml.
+#
+# YARD's .yardoc database (cached in CI) is incremental and additive: it
+# never drops objects for files that leave the source set, so a database
+# built under one set of YARD_OPTS stays contaminated for those files
+# forever once restored.  CI fallback cache keys omit the Makefile
+# checksum, so a Makefile change alone will still restore the old
+# .yardoc.  Bumping the cache prefix forces a clean rebuild and avoids
+# shipping stale types (e.g. test-only TestDate/TestTasks) in sig/rbi.
 YARD_OPTS = $(YARD_PLUGIN_OPTS) -c .yardoc --output-dir yardoc --backtrace --exclude '^config/' --exclude '^test/' '{lib,app}/**/*.rb' 'ext/**/*.{c,rb}'
 
 types.installed: tapioca.installed Gemfile.lock Gemfile.lock.installed rbi/checkoff.rbi sorbet/tapioca/require.rb sorbet/config ## Ensure typechecking dependencies are in place


### PR DESCRIPTION
## Summary

Release 0.249.0 still shipped a `sig/checkoff.rbs` byte-identical to 0.248.0, containing test-only types (`TestDate`, `TestTasks`, ...) despite #453 excluding `test/` from YARD. This broke downstream Sord/RBS collection (e.g. plate-spinner-rails) with `Duplicated declaration: ::TestDate::TIME_BY_PERIOD`.

Root cause: YARD's cached `.yardoc` database is **additive** — it never drops objects for files that leave the source set. I verified that running `yard doc` with the new test-excluding `YARD_OPTS` against the old cache leaves the test objects in place, while a clean rebuild produces none. CI's ruby-types cache primary key includes the `Makefile` checksum, but the fallback restore keys omit it, so a pre-#453 `.yardoc` kept getting restored and reused.

This bumps the cache version prefix `ruby-types-v7-` → `ruby-types-v8-`, forcing one clean rebuild so the published `sig`/`rbi` are regenerated from a `test/`-free database. It also documents, above `YARD_OPTS` in the `Makefile`, that the prefix must be bumped whenever the YARD source globs/excludes change.

## Changes vs `main`

- `.circleci/config.yml`: bump `ruby-types-v7-` → `ruby-types-v8-` across restore/save keys; add a short pointer note to the Makefile.
- `Makefile`: comment above `YARD_OPTS` explaining the additive-cache pitfall and the bump-the-prefix convention.

## How to test

- After this merges to `main`, the `build` job gets a ruby-types cache miss and rebuilds `.yardoc` cleanly; `publish_gem` then generates `sig/checkoff.rbs` without `TestDate`/`TestTasks`.
- Verify the next published gem's `sig/checkoff.rbs` no longer contains test-only types, then drop the `ignore: true` for checkoff in downstream `rbs_collection.yaml`.
