### PR TITLE
Force UTF-8 locale in .envrc

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -5,6 +5,15 @@
 
 PATH_add bin
 
+# Force a UTF-8 locale regardless of the invoking shell/tool's environment.
+# Without this, Ruby's default external encoding can fall back to US-ASCII
+# (e.g. when launched from an editor task runner or agent that doesn't carry
+# an interactive shell's LANG), which crashes parlour/sorbet-runtime with
+# "invalid byte sequence in US-ASCII" on any source file containing a
+# non-ASCII byte (smart quotes, em-dashes, etc. in comments).
+export LANG=en_US.UTF-8
+export LC_ALL=en_US.UTF-8
+
 # File probe: bootstrap hooks omit .envrc stderr; see bin/probe_env_local and
 # ~/.cache/env-local-probe/<worktree-basename>.log (also .env-local-probe-path).
 ENV_LOCAL_PROBE_SOURCE=envrc ENV_LOCAL_PROBE_QUIET=1 ./bin/probe_env_local || true


### PR DESCRIPTION
## Summary
- `bin/parlour run` (invoked by `make rbi/checkoff.rbi`) crashes with `EncodingError: invalid byte sequence in US-ASCII` when launched from a shell/tool that doesn't carry an interactive shell's `LANG`/`LC_ALL`.
- Root cause: Ruby's default external encoding falls back to `US-ASCII` when no locale is set, and several `lib/` files contain non-ASCII bytes (smart quotes, em-dashes) in comments — parlour's parser then dies on the first such file.
- Fix: export `LANG`/`LC_ALL=en_US.UTF-8` directly in `.envrc` so this no longer depends on the invoking environment already having a UTF-8 locale.

## Test plan
- [x] Verified `Encoding.default_external` is `US-ASCII` with locale vars unset, `UTF-8` with them set.
- [x] Ran `make rbi/checkoff.rbi` successfully with a UTF-8 locale.
- [x] Reproduced the crash with locale vars stripped, then confirmed `direnv export bash` now sets `+LANG +LC_ALL` and forces `UTF-8` even against a fully stripped ambient environment.

https://claude.ai/code/session_01WE1BSZ2o6yH8tCSswFqRnM
