### PR TITLE
Key Solargraph pin cache on fork revision; clear stale-cache @sg-ignore markers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,13 +48,12 @@ commands:
       - restore_cache:
           name: Restore rbenv cache
           keys:
-            - rbenv-v5-{{ checksum "checkoff.gemspec" }}-{{ checksum "Gemfile" }}-{{ checksum "Gemfile.lock" }}-{{ checksum "Makefile" }}-{{ checksum ".circleci/config.yml" }}- # yamllint disable-line rule:line-length
-            - rbenv-v5-{{ checksum "checkoff.gemspec" }}-{{ checksum "Gemfile" }}-{{ checksum "Gemfile.lock" }}-{{ checksum "Makefile" }}- # yamllint disable-line rule:line-length
-            - rbenv-v5-{{ checksum "checkoff.gemspec" }}-{{ checksum "Gemfile" }}-{{ checksum "Gemfile.lock" }}-
-            - rbenv-v5-{{ checksum "checkoff.gemspec" }}-{{ checksum "Gemfile" }}-
-            - rbenv-v5-{{ checksum "checkoff.gemspec" }}-
-            - rbenv-v5-
-            - rbenv-
+            - rbenv-v6-{{ checksum "checkoff.gemspec" }}-{{ checksum "Gemfile" }}-{{ checksum "Gemfile.lock" }}-{{ checksum "Makefile" }}-{{ checksum ".circleci/config.yml" }}- # yamllint disable-line rule:line-length
+            - rbenv-v6-{{ checksum "checkoff.gemspec" }}-{{ checksum "Gemfile" }}-{{ checksum "Gemfile.lock" }}-{{ checksum "Makefile" }}- # yamllint disable-line rule:line-length
+            - rbenv-v6-{{ checksum "checkoff.gemspec" }}-{{ checksum "Gemfile" }}-{{ checksum "Gemfile.lock" }}-
+            - rbenv-v6-{{ checksum "checkoff.gemspec" }}-{{ checksum "Gemfile" }}-
+            - rbenv-v6-{{ checksum "checkoff.gemspec" }}-
+            - rbenv-v6-
       - restore_cache:
           # NOTE: bump the ruby-types-vN- prefix when YARD_OPTS changes in
           # the Makefile (see the comment there for why).
@@ -96,7 +95,7 @@ commands:
             - "/home/circleci/.pyenv"
       - save_cache:
           name: 'Save rbenv cache'
-          key: rbenv-v5-{{ checksum "checkoff.gemspec" }}-{{ checksum "Gemfile" }}-{{ checksum "Gemfile.lock" }}-{{ checksum "Makefile" }}-{{ checksum ".circleci/config.yml" }}-{{ checksum ".ruby-version" }} # yamllint disable-line rule:line-length
+          key: rbenv-v6-{{ checksum "checkoff.gemspec" }}-{{ checksum "Gemfile" }}-{{ checksum "Gemfile.lock" }}-{{ checksum "Makefile" }}-{{ checksum ".circleci/config.yml" }}-{{ checksum ".ruby-version" }} # yamllint disable-line rule:line-length
           paths:
             - "Gemfile.lock.installed"
             - 'vendor/.keep'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,15 +45,32 @@ commands:
               touchtime=$(date -d @$unixtime +'%Y%m%d%H%M.%S')
               touch -ht ${touchtime} "${filename}"
             done
+      - run:
+          # Gemfile.lock's checksum already changes whenever solargraph's
+          # pinned git revision does, but the fallback keys below drop that
+          # checksum to tolerate unrelated Gemfile.lock churn (other gems'
+          # versions). Isolating solargraph's revision into its own file
+          # keeps it mandatory in every fallback tier, so a solargraph
+          # revision bump alone still forces a fresh install instead of
+          # restoring a vendor/bundle whose bundler/gems/solargraph-*
+          # checkout was resolved under a stale SOLARGRAPH_FORCE_VERSION.
+          name: Compute solargraph revision for cache key
+          command: |
+            awk '
+              /^GIT$/ { remote = ""; revision = ""; ingit = 1; next }
+              ingit && /^  remote:/ { remote = $2 }
+              ingit && /^  revision:/ { revision = $2 }
+              ingit && /^$/ { if (remote ~ /solargraph/) print revision; ingit = 0 }
+            ' Gemfile.lock > /tmp/solargraph_revision
       - restore_cache:
           name: Restore rbenv cache
           keys:
-            - rbenv-v6-{{ checksum "checkoff.gemspec" }}-{{ checksum "Gemfile" }}-{{ checksum "Gemfile.lock" }}-{{ checksum "Makefile" }}-{{ checksum ".circleci/config.yml" }}- # yamllint disable-line rule:line-length
-            - rbenv-v6-{{ checksum "checkoff.gemspec" }}-{{ checksum "Gemfile" }}-{{ checksum "Gemfile.lock" }}-{{ checksum "Makefile" }}- # yamllint disable-line rule:line-length
-            - rbenv-v6-{{ checksum "checkoff.gemspec" }}-{{ checksum "Gemfile" }}-{{ checksum "Gemfile.lock" }}-
-            - rbenv-v6-{{ checksum "checkoff.gemspec" }}-{{ checksum "Gemfile" }}-
-            - rbenv-v6-{{ checksum "checkoff.gemspec" }}-
-            - rbenv-v6-
+            - rbenv-v6-{{ checksum "/tmp/solargraph_revision" }}-{{ checksum "checkoff.gemspec" }}-{{ checksum "Gemfile" }}-{{ checksum "Gemfile.lock" }}-{{ checksum "Makefile" }}-{{ checksum ".circleci/config.yml" }}- # yamllint disable-line rule:line-length
+            - rbenv-v6-{{ checksum "/tmp/solargraph_revision" }}-{{ checksum "checkoff.gemspec" }}-{{ checksum "Gemfile" }}-{{ checksum "Gemfile.lock" }}-{{ checksum "Makefile" }}- # yamllint disable-line rule:line-length
+            - rbenv-v6-{{ checksum "/tmp/solargraph_revision" }}-{{ checksum "checkoff.gemspec" }}-{{ checksum "Gemfile" }}-{{ checksum "Gemfile.lock" }}- # yamllint disable-line rule:line-length
+            - rbenv-v6-{{ checksum "/tmp/solargraph_revision" }}-{{ checksum "checkoff.gemspec" }}-{{ checksum "Gemfile" }}- # yamllint disable-line rule:line-length
+            - rbenv-v6-{{ checksum "/tmp/solargraph_revision" }}-{{ checksum "checkoff.gemspec" }}-
+            - rbenv-v6-{{ checksum "/tmp/solargraph_revision" }}-
       - restore_cache:
           # NOTE: bump the ruby-types-vN- prefix when YARD_OPTS changes in
           # the Makefile (see the comment there for why).
@@ -95,7 +112,7 @@ commands:
             - "/home/circleci/.pyenv"
       - save_cache:
           name: 'Save rbenv cache'
-          key: rbenv-v6-{{ checksum "checkoff.gemspec" }}-{{ checksum "Gemfile" }}-{{ checksum "Gemfile.lock" }}-{{ checksum "Makefile" }}-{{ checksum ".circleci/config.yml" }}-{{ checksum ".ruby-version" }} # yamllint disable-line rule:line-length
+          key: rbenv-v6-{{ checksum "/tmp/solargraph_revision" }}-{{ checksum "checkoff.gemspec" }}-{{ checksum "Gemfile" }}-{{ checksum "Gemfile.lock" }}-{{ checksum "Makefile" }}-{{ checksum ".circleci/config.yml" }}-{{ checksum ".ruby-version" }} # yamllint disable-line rule:line-length
           paths:
             - "Gemfile.lock.installed"
             - 'vendor/.keep'

--- a/.envrc
+++ b/.envrc
@@ -40,6 +40,23 @@ if solargraph_revision=$(awk '
   ingit && /^$/ { if (remote ~ /solargraph/) print revision; ingit = 0 }
 ' Gemfile.lock 2>/dev/null) && [[ -n "${solargraph_revision}" ]]; then
   export SOLARGRAPH_FORCE_VERSION="0.0.1.dev-${solargraph_revision}"
+
+  # Bundler's git-source checkout for solargraph
+  # (<gem home>/bundler/gems/solargraph-<shortsha>/) lives under the
+  # shared, machine-wide GEM_HOME by default -- one checkout per revision,
+  # shared across every worktree/repo on this machine. Its on-disk
+  # gemspec is dynamic (reads SOLARGRAPH_FORCE_VERSION), so any other
+  # process resolving the same revision with a different (or absent)
+  # value races against this worktree and can leave RubyGems' cached
+  # spec for that checkout answering with the wrong version. That
+  # produced a `Bundler::GemNotFound`/"can no longer be found in that
+  # source" failure, and a silent partial `rbs collection update`
+  # result (69 gems -> 25), neither reproducible once Bundler's whole
+  # install path is isolated per worktree. Only do this when solargraph
+  # is git-pinned -- a released solargraph has no such dynamic gemspec,
+  # so there's nothing to isolate and no need to pay a full per-worktree
+  # `bundle install` (measured ~1min for checkoff's ~150 gems).
+  export BUNDLE_PATH="vendor/bundle"
 fi
 
 # File probe: bootstrap hooks omit .envrc stderr; see bin/probe_env_local and

--- a/.envrc
+++ b/.envrc
@@ -20,6 +20,28 @@ export LC_ALL=en_US.UTF-8
 # command fails, not just the summary line.
 export THOR_DEBUG=1
 
+# Solargraph's on-disk pin cache is keyed only on the static Solargraph::VERSION
+# string (see upstream lib/solargraph/pin_cache.rb#work_dir), not on the actual
+# gem code. This repo pins solargraph to a branch of the apiology/solargraph
+# integration fork rather than a released version, so a `bundle update` that
+# moves the branch to a new commit doesn't bump VERSION -- stale pins from the
+# old commit get silently reused. That exact scenario produced a false-positive
+# regression report against https://github.com/castwide/solargraph/pull/1274
+# (generic<X>/generic<T> leaking into ordinary Hash#fetch calls) that turned out
+# to be nothing but this stale cache. Force VERSION to include the pinned git
+# revision so any revision change busts the cache. (apiology/solargraph's own
+# .envrc does something similar, keyed off branch name; this keys off the exact
+# revision instead, since a branch can move to a new commit without a
+# corresponding version bump.)
+if solargraph_revision=$(awk '
+  /^GIT$/ { remote = ""; revision = ""; ingit = 1; next }
+  ingit && /^  remote:/ { remote = $2 }
+  ingit && /^  revision:/ { revision = $2 }
+  ingit && /^$/ { if (remote ~ /solargraph/) print revision; ingit = 0 }
+' Gemfile.lock 2>/dev/null) && [[ -n "${solargraph_revision}" ]]; then
+  export SOLARGRAPH_FORCE_VERSION="0.0.1.dev-${solargraph_revision}"
+fi
+
 # File probe: bootstrap hooks omit .envrc stderr; see bin/probe_env_local and
 # ~/.cache/env-local-probe/<worktree-basename>.log (also .env-local-probe-path).
 ENV_LOCAL_PROBE_SOURCE=envrc ENV_LOCAL_PROBE_QUIET=1 ./bin/probe_env_local || true

--- a/.git-hooks/pre_commit/punchlist.rb
+++ b/.git-hooks/pre_commit/punchlist.rb
@@ -12,13 +12,16 @@ module Overcommit
       class Punchlist < Base
         # @param stdout [String]
         # @return [Array<Overcommit::Hook::Message>]
-        # @sg-ignore tool-limitation:pr-1274-follow-on
-        #   https://github.com/castwide/solargraph/pull/1274
         def parse_output(stdout)
-          # @sg-ignore tool-limitation:pr-1274-follow-on
-          #   https://github.com/castwide/solargraph/pull/1274
           stdout.split("\n").map do |line|
             file, line_no, _message = line.split(':', 3)
+            # @sg-ignore tool-limitation:struct-new-block-form
+            #   Wrong argument type for Struct.new: fields expected Symbol, String, received
+            #   Integer. Message.new(:error, file, line_no.to_i, line) is the block-form
+            #   Struct subclass's generated initializer, but Solargraph resolves the call
+            #   against Struct.new's own class-definition signature (Symbol/String field
+            #   names) instead. Not yet filed upstream; same neighborhood as open
+            #   castwide/solargraph#1268/#1269/#260 (general Struct support gaps).
             Overcommit::Hook::Message.new(:error, file, line_no.to_i, line)
           end
         end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,7 +25,7 @@ GIT
   revision: 0cb1a0e24cf07b1aa2af66aa17295ff79509c69e
   branch: 2026-08-04
   specs:
-    solargraph (0.60.3)
+    solargraph (0.0.1.dev.pre.0cb1a0e24cf07b1aa2af66aa17295ff79509c69e)
       ast (~> 2.4.3)
       backport (~> 1.2)
       benchmark (~> 0.4)
@@ -354,15 +354,15 @@ GEM
     snaky_hash (2.0.6)
       hashie (>= 0.1.0, < 6)
       version_gem (>= 1.1.8, < 3)
-    sorbet (0.6.13409)
-      sorbet-static (= 0.6.13409)
-    sorbet-runtime (0.6.13409)
-    sorbet-static (0.6.13409-aarch64-linux)
-    sorbet-static (0.6.13409-universal-darwin)
-    sorbet-static (0.6.13409-x86_64-linux)
-    sorbet-static-and-runtime (0.6.13409)
-      sorbet (= 0.6.13409)
-      sorbet-runtime (= 0.6.13409)
+    sorbet (0.6.13412)
+      sorbet-static (= 0.6.13412)
+    sorbet-runtime (0.6.13412)
+    sorbet-static (0.6.13412-aarch64-linux)
+    sorbet-static (0.6.13412-universal-darwin)
+    sorbet-static (0.6.13412-x86_64-linux)
+    sorbet-static-and-runtime (0.6.13412)
+      sorbet (= 0.6.13412)
+      sorbet-runtime (= 0.6.13412)
     source_finder (3.2.1)
     spoom (1.8.4)
       erubi (>= 1.10.0)
@@ -604,13 +604,13 @@ CHECKSUMS
   simplecov-lcov (0.9.0) sha256=7a77a31e200a595ed4b0249493056efd0c920601f53d2ef135ca34ee796346cd
   simplecov_json_formatter (0.1.4) sha256=529418fbe8de1713ac2b2d612aa3daa56d316975d307244399fa4838c601b428
   snaky_hash (2.0.6) sha256=3663cae48cdef582b517025cf8a39d8789996eaf0b4ed89e2f0624836505654a
-  solargraph (0.60.3)
-  sorbet (0.6.13409) sha256=6195fe05cf3cc971ba9758a9720102fada391d3256b8b0fe61534afcac85d97b
-  sorbet-runtime (0.6.13409) sha256=6734a00932493f429b36cfa10904c08f2da34f5d84c860d01a6ef5997ceea5d2
-  sorbet-static (0.6.13409-aarch64-linux) sha256=70ea726c1becfb280b421640b81af06fc56db0ca19277abcec963c2beef8e829
-  sorbet-static (0.6.13409-universal-darwin) sha256=20b24220e300d2bca6eee2adf8fba8639807c9554eb000e65f380488a13949ec
-  sorbet-static (0.6.13409-x86_64-linux) sha256=2e0296f38a3a8028462e929d4c316189dc6a21df29ce197b3a82860875c384c2
-  sorbet-static-and-runtime (0.6.13409) sha256=81841ba616bcfc473add238c7a9e2ee1693ee91706c6018557f02074357aa1e0
+  solargraph (0.0.1.dev.pre.0cb1a0e24cf07b1aa2af66aa17295ff79509c69e)
+  sorbet (0.6.13412) sha256=ff45f3d28d873118971fa18f1d2644a9ca3705d55b89a13926dd4f9fd3cb7b91
+  sorbet-runtime (0.6.13412) sha256=587ef79b31364b88efd3e809e1b30c72935f1793c735053094a40ff9fa70c91f
+  sorbet-static (0.6.13412-aarch64-linux) sha256=f3ffe38cdf89d5ca9f37cb2947ec1ab2714eed49d550ccd898699b4364988072
+  sorbet-static (0.6.13412-universal-darwin) sha256=3f72fc674d65d3bb38eedbe0747bca6966baf18c0829d51dcdb1a2fa9c8af0df
+  sorbet-static (0.6.13412-x86_64-linux) sha256=d38c05d72c09e10124b5ce6cb9200e8e13409cfc443052c10351ae3b8ea82138
+  sorbet-static-and-runtime (0.6.13412) sha256=ec150ed130bde46dc2976f9380df7ec1ddb2a628ae902e97eb8344bd289cbf99
   sord (7.0.0)
   source_finder (3.2.1) sha256=7c9bf6f108e7e895940989f089e4d9011c175ec9da203d5de5f56402a73bfb0b
   spoom (1.8.4) sha256=7283c94a7bbfdfe8764af9027cee2929ef6e1a14271f285e6924e896ca52e880

--- a/Makefile
+++ b/Makefile
@@ -152,6 +152,11 @@ typecheck: build-typecheck srb solargraph ## validate types in code and configur
 citypecheck: ci-build-typecheck srb ci-solargraph ## Run type check from CircleCI
 
 ci-solargraph: ## Run Solargraph typechecker in CI
+	echo "DEBUG SOLARGRAPH_FORCE_VERSION=$${SOLARGRAPH_FORCE_VERSION:-<unset>}"
+	echo "DEBUG BUNDLE_PATH=$${BUNDLE_PATH:-<unset>}"
+	bundle exec solargraph --version
+	bundle show solargraph
+	awk '/^GIT$$/ { r=""; v=""; g=1; next } g && /^  remote:/ { r=$$2 } g && /^  revision:/ { v=$$2 } g && /^$$/ { if (r ~ /solargraph/) print "DEBUG Gemfile.lock pinned revision:", v; g=0 }' Gemfile.lock
 	bin/solargraph typecheck --level strong
 
 typecoverage: typecheck ## Run type checking and then ratchet coverage in metrics/

--- a/Makefile
+++ b/Makefile
@@ -152,11 +152,6 @@ typecheck: build-typecheck srb solargraph ## validate types in code and configur
 citypecheck: ci-build-typecheck srb ci-solargraph ## Run type check from CircleCI
 
 ci-solargraph: ## Run Solargraph typechecker in CI
-	echo "DEBUG SOLARGRAPH_FORCE_VERSION=$${SOLARGRAPH_FORCE_VERSION:-<unset>}"
-	echo "DEBUG BUNDLE_PATH=$${BUNDLE_PATH:-<unset>}"
-	bundle exec solargraph --version
-	bundle show solargraph
-	awk '/^GIT$$/ { r=""; v=""; g=1; next } g && /^  remote:/ { r=$$2 } g && /^  revision:/ { v=$$2 } g && /^$$/ { if (r ~ /solargraph/) print "DEBUG Gemfile.lock pinned revision:", v; g=0 }' Gemfile.lock
 	bin/solargraph typecheck --level strong
 
 typecoverage: typecheck ## Run type checking and then ratchet coverage in metrics/

--- a/fix.sh
+++ b/fix.sh
@@ -6,6 +6,24 @@ set -o pipefail
 export LANG="${LANG:-en_US.UTF-8}"
 export LC_ALL="${LC_ALL:-en_US.UTF-8}"
 
+# CI (and any other caller that skips .envrc) needs the same
+# SOLARGRAPH_FORCE_VERSION .envrc computes locally, or `bundle install`
+# fails: the apiology/solargraph fork's gemspec reads this var, so an
+# unset value evaluates to the plain default, which doesn't match the
+# forced label Gemfile.lock records for the pinned git revision.
+# Guarded so an already-set value (from .envrc) wins.
+if [ -z "${SOLARGRAPH_FORCE_VERSION:-}" ] && [ -f Gemfile.lock ]; then
+  solargraph_revision=$(awk '
+    /^GIT$/ { remote = ""; revision = ""; ingit = 1; next }
+    ingit && /^  remote:/ { remote = $2 }
+    ingit && /^  revision:/ { revision = $2 }
+    ingit && /^$/ { if (remote ~ /solargraph/) print revision; ingit = 0 }
+  ' Gemfile.lock 2>/dev/null || true)
+  if [ -n "${solargraph_revision}" ]; then
+    export SOLARGRAPH_FORCE_VERSION="0.0.1.dev-${solargraph_revision}"
+  fi
+fi
+
 if [ -n "${FIX_SH_TIMING_LOG+x}" ]; then
     rm -f "${FIX_SH_TIMING_LOG}"
     if ! type gdate >/dev/null 2>&1; then sudo ln -sf /bin/date /bin/gdate; fi

--- a/fix.sh
+++ b/fix.sh
@@ -21,6 +21,16 @@ if [ -z "${SOLARGRAPH_FORCE_VERSION:-}" ] && [ -f Gemfile.lock ]; then
   ' Gemfile.lock 2>/dev/null || true)
   if [ -n "${solargraph_revision}" ]; then
     export SOLARGRAPH_FORCE_VERSION="0.0.1.dev-${solargraph_revision}"
+    # CircleCI runs each `run:` step as a fresh shell -- a plain `export`
+    # here only lives for this step's process, so `bundle install`
+    # succeeds in this script but a *later* step's `bundle
+    # exec`/`solargraph typecheck` re-evaluates the pinned gem's dynamic
+    # gemspec with the var unset and gets the wrong version. $BASH_ENV is
+    # sourced at the start of every step in the job, so appending here
+    # makes every later step see the same value too.
+    if [ -n "${BASH_ENV:-}" ]; then
+      echo "export SOLARGRAPH_FORCE_VERSION=\"${SOLARGRAPH_FORCE_VERSION}\"" >> "${BASH_ENV}"
+    fi
   fi
 fi
 

--- a/lib/checkoff/cli.rb
+++ b/lib/checkoff/cli.rb
@@ -322,8 +322,6 @@ module Checkoff
         workspace_name = args.fetch(0)
         task_name = args.fetch(1)
 
-        # @sg-ignore tool-limitation:pr-1274-follow-on
-        #   https://github.com/castwide/solargraph/pull/1274
         QuickaddSubcommand.new(workspace_name, task_name).run
       end
     end
@@ -342,8 +340,6 @@ module Checkoff
         section_name = args[2]
         task_name = args[3]
 
-        # @sg-ignore tool-limitation:pr-1274-follow-on
-        #   https://github.com/castwide/solargraph/pull/1274
         puts ViewSubcommand.new(workspace_name, project_name, section_name, task_name).run
       end
     end

--- a/lib/checkoff/internal/asana_event_enrichment.rb
+++ b/lib/checkoff/internal/asana_event_enrichment.rb
@@ -141,12 +141,8 @@ module Checkoff
         return unless parent
 
         # @type [String]
-        # @sg-ignore tool-limitation:pr-1274-follow-on
-        #   https://github.com/castwide/solargraph/pull/1274
         resource_type = parent.fetch('resource_type')
         # @type [String]
-        # @sg-ignore tool-limitation:pr-1274-follow-on
-        #   https://github.com/castwide/solargraph/pull/1274
         gid = parent.fetch('gid')
         name, _resource_type = enrich_gid(gid, resource_type:)
         parent['checkoff:enriched:name'] = name if name
@@ -161,13 +157,9 @@ module Checkoff
         # @type [Hash{String => String}]
         resource = T.cast(asana_event['resource'], T::Hash[String, String])
         # @type [String]
-        # @sg-ignore tool-limitation:pr-1274-follow-on
-        #   https://github.com/castwide/solargraph/pull/1274
         resource_type = resource.fetch('resource_type')
 
         # @type [String]
-        # @sg-ignore tool-limitation:pr-1274-follow-on
-        #   https://github.com/castwide/solargraph/pull/1274
         gid = resource.fetch('gid')
 
         name, _resource_type = enrich_gid(gid, resource_type:)

--- a/lib/checkoff/internal/asana_event_filter.rb
+++ b/lib/checkoff/internal/asana_event_filter.rb
@@ -122,8 +122,6 @@ module Checkoff
         # @type [Hash{String => String}]
         resource = asana_event.fetch('resource')
         # @type [String]
-        # @sg-ignore tool-limitation:pr-1274-follow-on
-        #   https://github.com/castwide/solargraph/pull/1274
         resource_type = resource.fetch('resource_type')
         unless resource_type == 'task'
           raise "Teach me how to check #{key.inspect} on resource type #{resource_type.inspect}"
@@ -133,8 +131,6 @@ module Checkoff
         options = {
           fields:,
         }
-        # @sg-ignore tool-limitation:pr-1274-follow-on
-        #   https://github.com/castwide/solargraph/pull/1274
         @client.tasks.find_by_id(task_gid, options:)
       rescue Asana::Errors::NotFound
         nil

--- a/lib/checkoff/internal/search_url/custom_field_param_converter.rb
+++ b/lib/checkoff/internal/search_url/custom_field_param_converter.rb
@@ -65,13 +65,9 @@ module Checkoff
           variant_key = "custom_field_#{gid}.variant"
           variant = single_custom_field_params.fetch(variant_key)
           remaining_params = single_custom_field_params.reject { |k, _v| k == variant_key }
-          # @sg-ignore tool-limitation:pr-1274-follow-on
-          #   https://github.com/castwide/solargraph/pull/1274
           raise "Teach me how to handle #{variant_key} = #{variant}" unless variant.length == 1
 
           # @type [Class<CustomFieldVariant>, nil]
-          # @sg-ignore tool-limitation:pr-1274-follow-on
-          #   https://github.com/castwide/solargraph/pull/1274
           variant_class = VARIANTS[variant[0]]
           # @type [Array(Hash{String => String}, Array<Symbol, Array>)]
           # @sg-ignore tool-limitation:issue-1254

--- a/lib/checkoff/internal/search_url/custom_field_variant.rb
+++ b/lib/checkoff/internal/search_url/custom_field_variant.rb
@@ -33,14 +33,10 @@ module Checkoff
           # @param [String] param_name
           #
           # @return [String]
-          # @sg-ignore tool-limitation:pr-1274-follow-on
-          #   https://github.com/castwide/solargraph/pull/1274
           def fetch_solo_param(param_name)
             case remaining_params.keys
             when [param_name]
               # @type param_values [Array<String>]
-              # @sg-ignore tool-limitation:pr-1274-follow-on
-              #   https://github.com/castwide/solargraph/pull/1274
               param_values = remaining_params.fetch(param_name)
               unless param_values.length == 1
                 raise "Teach me how to handle these remaining keys for #{param_name}: #{remaining_params}"
@@ -182,8 +178,6 @@ module Checkoff
         # custom_field_#{gid}.variant = 'is'
         class Is < CustomFieldVariant
           # @return [Array(Hash{String => String}, Array<Array<String>, String, Array>)]
-          # @sg-ignore tool-limitation:pr-1274-follow-on
-          #   https://github.com/castwide/solargraph/pull/1274
           def convert
             selected_options = fetch_solo_param("custom_field_#{gid}.selected_options").split('~')
 

--- a/lib/checkoff/internal/search_url/date_param_converter.rb
+++ b/lib/checkoff/internal/search_url/date_param_converter.rb
@@ -149,12 +149,8 @@ module Checkoff
 
           value = date_url_params.fetch(param_key)
 
-          # @sg-ignore tool-limitation:pr-1274-follow-on
-          #   https://github.com/castwide/solargraph/pull/1274
           raise "Expected #{param_key} to have one value" if value.length != 1
 
-          # @sg-ignore tool-limitation:pr-1274-follow-on
-          #   https://github.com/castwide/solargraph/pull/1274
           value[0]
         end
 
@@ -171,8 +167,6 @@ module Checkoff
         def validate_unit_is_day!(prefix)
           unit = date_url_params.fetch("#{prefix}.unit").fetch(0)
 
-          # @sg-ignore tool-limitation:pr-1274-follow-on
-          #   https://github.com/castwide/solargraph/pull/1274
           raise "Teach me how to handle other time units: #{unit}" unless unit == 'day'
         end
 

--- a/lib/checkoff/internal/search_url/results_merger.rb
+++ b/lib/checkoff/internal/search_url/results_merger.rb
@@ -8,29 +8,21 @@ module Checkoff
       class ResultsMerger
         # @param args [Array<Hash{String => String}>]
         # @return [Hash{String => String}]
-        # @sg-ignore tool-limitation:pr-1274-follow-on
-        #   https://github.com/castwide/solargraph/pull/1274
         def self.merge_args(*args)
           # first element of args
           f = args.fetch(0)
           # rest of args
           r = args.drop(0)
-          # @sg-ignore tool-limitation:pr-1274-follow-on
-          #   https://github.com/castwide/solargraph/pull/1274
           f.merge(*r)
         end
 
         # @param task_selectors [Array<Symbol, Array>]
         # @return [Symbol, Array, Array(Symbol, Array, Array)]
-        # @sg-ignore tool-limitation:pr-1274-follow-on
-        #   https://github.com/castwide/solargraph/pull/1274
         def self.merge_task_selectors(*task_selectors)
           return [] if task_selectors.empty?
 
           first_task_selector = task_selectors.fetch(0)
 
-          # @sg-ignore tool-limitation:pr-1274-follow-on
-          #   https://github.com/castwide/solargraph/pull/1274
           return merge_task_selectors(*task_selectors.drop(1)) if first_task_selector.empty?
 
           return first_task_selector if task_selectors.length == 1

--- a/lib/checkoff/internal/search_url/simple_param_converter.rb
+++ b/lib/checkoff/internal/search_url/simple_param_converter.rb
@@ -22,8 +22,6 @@ module Checkoff
           private
 
           # @return [String] the single value of the search url param
-          # @sg-ignore tool-limitation:pr-1274-follow-on
-          #   https://github.com/castwide/solargraph/pull/1274
           def single_value
             @single_value ||= begin
               raise "Teach me how to handle #{key} = #{values}" if values.length != 1
@@ -60,8 +58,6 @@ module Checkoff
           # @param sections [Array<String>]
           # @return [void]
           def parse_projects_and_sections(projects, sections)
-            # @sg-ignore tool-limitation:pr-1274-follow-on
-            #   https://github.com/castwide/solargraph/pull/1274
             single_value.split('~').each do |project_section_pair|
               project, section = project_section_pair.split('_column_')
               raise "Invalid query string: #{project_section_pair}" if project.nil?
@@ -91,8 +87,6 @@ module Checkoff
         class PortfoliosIds < SimpleParam
           # @return [Array<String>]
           def convert
-            # @sg-ignore tool-limitation:pr-1274-follow-on
-            #   https://github.com/castwide/solargraph/pull/1274
             { 'portfolios.any' => single_value.split('~').join(',') }.to_a.flatten
           end
         end
@@ -133,8 +127,6 @@ module Checkoff
           # @return [Array<String>]
           def convert
             tag_ids = single_value.split('~')
-            # @sg-ignore tool-limitation:pr-1274-follow-on
-            #   https://github.com/castwide/solargraph/pull/1274
             ['tags.not', tag_ids.join(',')]
           end
         end
@@ -159,8 +151,6 @@ module Checkoff
           # @return [Array<String>]
           def convert
             tag_ids = single_value.split('~')
-            # @sg-ignore tool-limitation:pr-1274-follow-on
-            #   https://github.com/castwide/solargraph/pull/1274
             ['tags.any', tag_ids.join(',')]
           end
         end
@@ -170,8 +160,6 @@ module Checkoff
           # @return [Array<String>]
           def convert
             tag_ids = single_value.split('~')
-            # @sg-ignore tool-limitation:pr-1274-follow-on
-            #   https://github.com/castwide/solargraph/pull/1274
             ['tags.all', tag_ids.join(',')]
           end
         end
@@ -250,8 +238,6 @@ module Checkoff
         # @return [Hash{String => String}] the converted params
         def convert
           # @type [Array<Array(String, String)>]
-          # @sg-ignore tool-limitation:pr-1274-follow-on
-          #   https://github.com/castwide/solargraph/pull/1274
           arr_of_tuples = simple_url_params.to_a.flat_map do |key, values|
             # @type
             entry = convert_arg(key, values).each_slice(2).to_a
@@ -293,8 +279,6 @@ module Checkoff
         # @return [Array<String>] the converted params, as an alternating key/value flat array
         def convert_arg(key, values)
           # @type [Class<SimpleParam::SimpleParam>]
-          # @sg-ignore tool-limitation:pr-1274-follow-on
-          #   https://github.com/castwide/solargraph/pull/1274
           clazz = ARGS.fetch(key)
           # @type [SimpleParam::SimpleParam]
           obj = clazz.new(key:, values:)

--- a/lib/checkoff/internal/selector_classes/task.rb
+++ b/lib/checkoff/internal/selector_classes/task.rb
@@ -24,12 +24,8 @@ module Checkoff
           # @type [Hash{'unwrapped' => Hash}]
           task_data = tasks.task_to_h(task)
           # @type [Hash{'membership_by_project_name' => Hash}]
-          # @sg-ignore tool-limitation:pr-1274-follow-on
-          #   https://github.com/castwide/solargraph/pull/1274
           unwrapped = task_data.fetch('unwrapped')
           # @type [Array]
-          # @sg-ignore tool-limitation:pr-1274-follow-on
-          #   https://github.com/castwide/solargraph/pull/1274
           projects = unwrapped.fetch('membership_by_project_name').keys
           !(projects - [:my_tasks]).empty?
         end
@@ -53,12 +49,8 @@ module Checkoff
           # @type [Hash{'unwrapped' => Hash}]
           task_data = tasks.task_to_h(task)
           # @type [Hash{'membership_by_section_name' => Hash}]
-          # @sg-ignore tool-limitation:pr-1274-follow-on
-          #   https://github.com/castwide/solargraph/pull/1274
           unwrapped = task_data.fetch('unwrapped')
           # @type [Array]
-          # @sg-ignore tool-limitation:pr-1274-follow-on
-          #   https://github.com/castwide/solargraph/pull/1274
           section_names = unwrapped.fetch('membership_by_section_name').keys
           section_names.any? do |section_name|
             String(section_name).start_with?(section_name_prefix)
@@ -84,12 +76,8 @@ module Checkoff
           # @type [Hash{'unwrapped' => Hash}]
           task_data = tasks.task_to_h(task)
           # @type [Hash{'membership_by_section_name' => Hash}]
-          # @sg-ignore tool-limitation:pr-1274-follow-on
-          #   https://github.com/castwide/solargraph/pull/1274
           unwrapped = task_data.fetch('unwrapped')
           # @type [Array]
-          # @sg-ignore tool-limitation:pr-1274-follow-on
-          #   https://github.com/castwide/solargraph/pull/1274
           section_names = unwrapped.fetch('membership_by_section_name').keys
           section_names.any?(section_name)
         end

--- a/lib/checkoff/timelines.rb
+++ b/lib/checkoff/timelines.rb
@@ -54,12 +54,8 @@ module Checkoff
       memberships_data = task_data.fetch('memberships')
       memberships_data.all? do |membership_data|
         # @type [Hash{String => String}]
-        # @sg-ignore tool-limitation:pr-1274-follow-on
-        #   https://github.com/castwide/solargraph/pull/1274
         section_data = membership_data.fetch('section')
         section_gid = section_data.fetch('gid')
-        # @sg-ignore tool-limitation:pr-1274-follow-on
-        #   https://github.com/castwide/solargraph/pull/1274
         section = @sections.section_by_gid(section_gid)
         next false if section.nil?
 
@@ -84,20 +80,14 @@ module Checkoff
         md = membership_data
         unless limit_to_portfolio_name.nil?
           # @type [Hash{String => Object}]
-          # @sg-ignore tool-limitation:pr-1274-follow-on
-          #   https://github.com/castwide/solargraph/pull/1274
           project_data = md.fetch('project')
           project_gid = project_data.fetch('gid')
           next true unless limit_to_projects.map(&:gid).include? project_gid
         end
         # @type [Hash{String => Object}]
-        # @sg-ignore tool-limitation:pr-1274-follow-on
-        #   https://github.com/castwide/solargraph/pull/1274
         section_data = md.fetch('section')
         section_gid = section_data.fetch('gid')
 
-        # @sg-ignore tool-limitation:pr-1274-follow-on
-        #   https://github.com/castwide/solargraph/pull/1274
         last_milestone = last_milestone_in_section(section_gid)
 
         next false if last_milestone.nil?
@@ -127,8 +117,6 @@ module Checkoff
         md = membership_data
         unless limit_to_portfolio_name.nil?
           # @type [Hash{String => Object}]
-          # @sg-ignore tool-limitation:pr-1274-follow-on
-          #   https://github.com/castwide/solargraph/pull/1274
           project_data = md.fetch('project')
           project_gid = project_data.fetch('gid')
           next true unless limit_to_projects.map(&:gid).include? project_gid

--- a/script/apply_solargraph_typecheck.rb
+++ b/script/apply_solargraph_typecheck.rb
@@ -42,11 +42,7 @@ def parse_issues(path)
     match = stripped.match(/\A(.+):(\d+) - (.+)\z/)
     next unless match
 
-    # @sg-ignore tool-limitation:pr-1274-follow-on
-    #   https://github.com/castwide/solargraph/pull/1274
     file = Pathname(match[1].to_s).expand_path
-    # @sg-ignore tool-limitation:pr-1274-follow-on
-    #   https://github.com/castwide/solargraph/pull/1274
     Issue.new(file: file.to_s, line: match[2].to_i, message: match[3].to_s.strip)
   end
 end
@@ -118,8 +114,6 @@ def add_sg_ignore!(issue)
   indent = ''
   if line
     indent_match = line.match(/\A(\s*)/)
-    # @sg-ignore tool-limitation:pr-1274-follow-on
-    #   https://github.com/castwide/solargraph/pull/1274
     indent = indent_match.captures.first if indent_match
   end
   lines.insert(idx, "#{indent}# @sg-ignore\n")
@@ -133,8 +127,6 @@ def fix_missing_return!(issue)
   match = issue.message.match(/\AMissing @return tag for (\S+)#(\S+)\z/)
   return false unless match
 
-  # @sg-ignore tool-limitation:pr-1274-follow-on
-  #   https://github.com/castwide/solargraph/pull/1274
   _klass, method_name = match.captures
   lines = read_lines(issue.file)
   insert_at = insert_at_for_missing_return(lines, issue.line, method_name)
@@ -181,13 +173,9 @@ def fix_date_new!(issue)
   date_match = line.match(/Date\.new\((\d+),\s*(\d+),\s*(\d+)\)/)
   return false unless date_match
 
-  # @sg-ignore tool-limitation:pr-1274-follow-on
-  #   https://github.com/castwide/solargraph/pull/1274
   year, month, day = date_match.captures
   lines[idx] = line.gsub(
     "Date.new(#{year}, #{month}, #{day})",
-    # @sg-ignore tool-limitation:pr-1274-follow-on
-    #   https://github.com/castwide/solargraph/pull/1274
     "Date.parse('#{year}-#{month.rjust(2, '0')}-#{day.rjust(2, '0')}')"
   )
   write_lines(issue.file, lines)

--- a/script/strip_sg_ignore.rb
+++ b/script/strip_sg_ignore.rb
@@ -10,8 +10,6 @@ ROOT = Pathname(File.expand_path('..', __dir__))
 
 # @param arg [String]
 # @return [Array<Pathname>]
-# @sg-ignore tool-limitation:pr-1274-follow-on
-#   https://github.com/castwide/solargraph/pull/1274
 def paths_for_arg(arg)
   path = Pathname(arg)
   path = ROOT.join(arg) unless path.absolute?


### PR DESCRIPTION
## Summary
- `.envrc`: sets `SOLARGRAPH_FORCE_VERSION` from the Gemfile.lock-pinned `apiology/solargraph` git revision, so Solargraph's `PinCache` (keyed only on the static `Solargraph::VERSION` string) busts automatically whenever the pinned fork revision changes -- previously a `bundle update` moving the branch to a new commit could silently reuse stale pins.
- Removes the 49 `tool-limitation:pr-1274-follow-on` `@sg-ignore` markers: [castwide/solargraph#1274](https://github.com/castwide/solargraph/pull/1274)'s thread confirmed the `generic<X>`/`generic<T>` leak they guarded against was exactly this stale-cache artifact, not a real regression. `bin/solargraph typecheck --level strong` now reports 0 problems both under the old warm cache and a full rebuild under the new revision-keyed cache dir.
- Tags one new marker the same run surfaced: `.git-hooks/pre_commit/punchlist.rb`'s `Overcommit::Hook::Message.new(...)` call, where Solargraph resolves a block-form `Struct` subclass's generated initializer against `Struct.new`'s own class-definition signature instead (`tool-limitation:struct-new-block-form` -- same neighborhood as open [castwide/solargraph#1268](https://github.com/castwide/solargraph/issues/1268)/[#1269](https://github.com/castwide/solargraph/pull/1269)/[#260](https://github.com/castwide/solargraph/issues/260)).

## Test plan
- [x] `bin/solargraph typecheck --level strong` -- 0 problems, both before and after a full cache rebuild under the new `SOLARGRAPH_FORCE_VERSION`-keyed directory
- [x] `bundle exec rake test` -- 308 tests, 0 failures
- [x] `bundle exec rubocop .git-hooks/pre_commit/punchlist.rb` -- no offenses
