### PR TITLE
Anchor solargraph GIT-block regex to the exact repo name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ commands:
               /^GIT$/ { remote = ""; revision = ""; ingit = 1; next }
               ingit && /^  remote:/ { remote = $2 }
               ingit && /^  revision:/ { revision = $2 }
-              ingit && /^$/ { if (remote ~ /solargraph/) print revision; ingit = 0 }
+              ingit && /^$/ { if (remote ~ /\/solargraph(\.git)?$/) print revision; ingit = 0 }
             ' Gemfile.lock > /tmp/solargraph_revision
       - restore_cache:
           name: Restore rbenv cache

--- a/.envrc
+++ b/.envrc
@@ -37,7 +37,7 @@ if solargraph_revision=$(awk '
   /^GIT$/ { remote = ""; revision = ""; ingit = 1; next }
   ingit && /^  remote:/ { remote = $2 }
   ingit && /^  revision:/ { revision = $2 }
-  ingit && /^$/ { if (remote ~ /solargraph/) print revision; ingit = 0 }
+  ingit && /^$/ { if (remote ~ /\/solargraph(\.git)?$/) print revision; ingit = 0 }
 ' Gemfile.lock 2>/dev/null) && [[ -n "${solargraph_revision}" ]]; then
   export SOLARGRAPH_FORCE_VERSION="0.0.1.dev-${solargraph_revision}"
 

--- a/fix.sh
+++ b/fix.sh
@@ -17,7 +17,7 @@ if [ -z "${SOLARGRAPH_FORCE_VERSION:-}" ] && [ -f Gemfile.lock ]; then
     /^GIT$/ { remote = ""; revision = ""; ingit = 1; next }
     ingit && /^  remote:/ { remote = $2 }
     ingit && /^  revision:/ { revision = $2 }
-    ingit && /^$/ { if (remote ~ /solargraph/) print revision; ingit = 0 }
+    ingit && /^$/ { if (remote ~ /\/solargraph(\.git)?$/) print revision; ingit = 0 }
   ' Gemfile.lock 2>/dev/null || true)
   if [ -n "${solargraph_revision}" ]; then
     export SOLARGRAPH_FORCE_VERSION="0.0.1.dev-${solargraph_revision}"


### PR DESCRIPTION
## Summary

Follow-up to https://github.com/apiology/checkoff/pull/469 (merged). The `awk` pattern used to detect solargraph's pinned git revision (`.envrc`, `fix.sh`, `.circleci/config.yml`) matched `remote ~ /solargraph/` -- a substring match, not an exact one. Found while porting the same guard to `apiology/plate-spinner-rails`, which pins a *different* git-sourced gem (`iftheshoefritz/solargraph-rails`) whose remote also matches that pattern. Harmless in this repo today only because no other git-pinned gem here happens to contain "solargraph" as a substring.

Anchored to match only a remote URL path ending in exactly `solargraph` (optionally `.git`), so a future git-pinned gem name containing "solargraph" as a substring can't trigger a false match.

## Test plan

- [x] `direnv exec . env | grep SOLARGRAPH_FORCE_VERSION` still resolves the correct forced version for the currently-pinned revision
- [x] `bundle check` still reports satisfied
- [x] `bash -n fix.sh` / `yamllint .circleci/config.yml` clean
- [ ] CircleCI `build`/`quality` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S3YDrArZm1e4DQ3MnFCSZk
