### PR TITLE
Track apiology/solargraph fork pin forward, resolve two sg-ignores

### DIFF
--- a/.git-hooks/bootstrap_local_overcommit.rb
+++ b/.git-hooks/bootstrap_local_overcommit.rb
@@ -37,14 +37,6 @@ local_file = File.join(repo_root, '.local-overcommit.yml')
 
 unless File.exist?(local_file)
   source = sibling_worktree_local_overcommit(repo_root)
-  # @sg-ignore tool-limitation:pr-1281-follow-on
-  #   https://github.com/castwide/solargraph/pull/1281 merged (branch 2026-08-04 @
-  #   4dae548) but does not clear this call: still "Wrong argument type for
-  #   FileUtils.ln_sf: src expected FileUtils::path, Array, received String".
-  #   Confirmed via strip-and-observe against the post-merge revision with a cleared
-  #   pin cache. This src param is FileUtils::pathlist (path | Array[path]), not the
-  #   dest param's plain FileUtils::path that #1281's repro targeted -- may be a
-  #   distinct alias-expansion gap, or a partial fix. Not yet re-filed.
   FileUtils.ln_sf(source, local_file) if source
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,10 +22,10 @@ GIT
 
 GIT
   remote: https://github.com/apiology/solargraph.git
-  revision: cd567a0ad8c77934a6be5b8451d9b16ae7e5bfb8
+  revision: a6942fc53231d8fe4f1e16599774a27f86af8574
   branch: 2026-08-04
   specs:
-    solargraph (0.0.1.dev.pre.cd567a0ad8c77934a6be5b8451d9b16ae7e5bfb8)
+    solargraph (0.0.1.dev.pre.a6942fc53231d8fe4f1e16599774a27f86af8574)
       ast (~> 2.4.3)
       backport (~> 1.2)
       benchmark (~> 0.4)
@@ -604,7 +604,7 @@ CHECKSUMS
   simplecov-lcov (0.9.0) sha256=7a77a31e200a595ed4b0249493056efd0c920601f53d2ef135ca34ee796346cd
   simplecov_json_formatter (0.1.4) sha256=529418fbe8de1713ac2b2d612aa3daa56d316975d307244399fa4838c601b428
   snaky_hash (2.0.6) sha256=3663cae48cdef582b517025cf8a39d8789996eaf0b4ed89e2f0624836505654a
-  solargraph (0.0.1.dev.pre.cd567a0ad8c77934a6be5b8451d9b16ae7e5bfb8)
+  solargraph (0.0.1.dev.pre.a6942fc53231d8fe4f1e16599774a27f86af8574)
   sorbet (0.6.13425) sha256=255356926b7f95c35481cace5806b8b5f7849f8c2e635a426e1ba37ab1ecd913
   sorbet-runtime (0.6.13425) sha256=92f55873199d8bb259ce20c4fc02d95b63e8d6c0c5abba60b7c67054f175f147
   sorbet-static (0.6.13425-aarch64-linux) sha256=abfc2732b524e0e688639969716943d338340f50340f6341315911a532b81e05

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,10 +22,10 @@ GIT
 
 GIT
   remote: https://github.com/apiology/solargraph.git
-  revision: 1933086868c782b9224be19964bb0cbd129858af
+  revision: cd567a0ad8c77934a6be5b8451d9b16ae7e5bfb8
   branch: 2026-08-04
   specs:
-    solargraph (0.0.1.dev.pre.1933086868c782b9224be19964bb0cbd129858af)
+    solargraph (0.0.1.dev.pre.cd567a0ad8c77934a6be5b8451d9b16ae7e5bfb8)
       ast (~> 2.4.3)
       backport (~> 1.2)
       benchmark (~> 0.4)
@@ -604,7 +604,7 @@ CHECKSUMS
   simplecov-lcov (0.9.0) sha256=7a77a31e200a595ed4b0249493056efd0c920601f53d2ef135ca34ee796346cd
   simplecov_json_formatter (0.1.4) sha256=529418fbe8de1713ac2b2d612aa3daa56d316975d307244399fa4838c601b428
   snaky_hash (2.0.6) sha256=3663cae48cdef582b517025cf8a39d8789996eaf0b4ed89e2f0624836505654a
-  solargraph (0.0.1.dev.pre.1933086868c782b9224be19964bb0cbd129858af)
+  solargraph (0.0.1.dev.pre.cd567a0ad8c77934a6be5b8451d9b16ae7e5bfb8)
   sorbet (0.6.13425) sha256=255356926b7f95c35481cace5806b8b5f7849f8c2e635a426e1ba37ab1ecd913
   sorbet-runtime (0.6.13425) sha256=92f55873199d8bb259ce20c4fc02d95b63e8d6c0c5abba60b7c67054f175f147
   sorbet-static (0.6.13425-aarch64-linux) sha256=abfc2732b524e0e688639969716943d338340f50340f6341315911a532b81e05

--- a/lib/checkoff/attachments.rb
+++ b/lib/checkoff/attachments.rb
@@ -87,9 +87,8 @@ module Checkoff
       out = nil
       host = uri.host || raise("URI has no host: #{uri}")
       Net::HTTP.start(host, uri.port, use_ssl: uri.scheme == 'https', verify_mode:) do |http|
-        # @sg-ignore tool-limitation:generic-block-yield-overload
-        #   Unresolved call to request -- Net::HTTP.start's generic block-form overload
-        #   doesn't bind T, so the yielded http param stays untyped. Not yet filed upstream.
+        # @sg-ignore tool-limitation:pr-1290
+        #   https://github.com/castwide/solargraph/pull/1290
         http.request(Net::HTTP::Get.new(uri)) do |response|
           raise("Unexpected response code: #{response.code}") unless response.code == '200'
 

--- a/lib/checkoff/attachments.rb
+++ b/lib/checkoff/attachments.rb
@@ -87,8 +87,8 @@ module Checkoff
       out = nil
       host = uri.host || raise("URI has no host: #{uri}")
       Net::HTTP.start(host, uri.port, use_ssl: uri.scheme == 'https', verify_mode:) do |http|
-        # @sg-ignore tool-limitation:pr-1290
-        #   https://github.com/castwide/solargraph/pull/1290
+        # @sg-ignore tool-limitation:pr-1290-follow-up
+        #   https://github.com/castwide/solargraph/pull/1290#issuecomment-5272957964
         http.request(Net::HTTP::Get.new(uri)) do |response|
           raise("Unexpected response code: #{response.code}") unless response.code == '200'
 

--- a/lib/checkoff/internal/selector_classes/section.rb
+++ b/lib/checkoff/internal/selector_classes/section.rb
@@ -18,8 +18,6 @@ module Checkoff
         # @param section [Asana::Resources::Section]
         #
         # @return [Boolean]
-        # @sg-ignore tool-limitation:issue-1286
-        #   https://github.com/castwide/solargraph/issues/1286
         def evaluate(section)
           tasks = client.tasks.get_tasks(section: section.gid,
                                          per_page: 100,

--- a/rbs_collection.lock.yaml
+++ b/rbs_collection.lock.yaml
@@ -1,34 +1,10 @@
 ---
 path: ".gem_rbs_collection"
 gems:
-- name: activesupport
-  version: '7.0'
-  source:
-    type: git
-    name: ruby/gem_rbs_collection
-    revision: 2443035126922ee49f775a0edb0b705896fef7c6
-    remote: https://github.com/ruby/gem_rbs_collection.git
-    repo_dir: gems
-- name: addressable
-  version: '2.8'
-  source:
-    type: git
-    name: ruby/gem_rbs_collection
-    revision: 2443035126922ee49f775a0edb0b705896fef7c6
-    remote: https://github.com/ruby/gem_rbs_collection.git
-    repo_dir: gems
 - name: anonymous_loader
   version: 0.1.2
   source:
     type: rubygems
-- name: ast
-  version: '2.4'
-  source:
-    type: git
-    name: ruby/gem_rbs_collection
-    revision: 2443035126922ee49f775a0edb0b705896fef7c6
-    remote: https://github.com/ruby/gem_rbs_collection.git
-    repo_dir: gems
 - name: auth-sanitizer
   version: 0.2.2
   source:
@@ -45,94 +21,6 @@ gems:
   version: 4.1.2
   source:
     type: rubygems
-- name: cgi
-  version: '0.5'
-  source:
-    type: git
-    name: ruby/gem_rbs_collection
-    revision: 2443035126922ee49f775a0edb0b705896fef7c6
-    remote: https://github.com/ruby/gem_rbs_collection.git
-    repo_dir: gems
-- name: concurrent-ruby
-  version: '1.1'
-  source:
-    type: git
-    name: ruby/gem_rbs_collection
-    revision: 2443035126922ee49f775a0edb0b705896fef7c6
-    remote: https://github.com/ruby/gem_rbs_collection.git
-    repo_dir: gems
-- name: connection_pool
-  version: '2.4'
-  source:
-    type: git
-    name: ruby/gem_rbs_collection
-    revision: 2443035126922ee49f775a0edb0b705896fef7c6
-    remote: https://github.com/ruby/gem_rbs_collection.git
-    repo_dir: gems
-- name: date
-  version: '0'
-  source:
-    type: stdlib
-- name: delegate
-  version: '0'
-  source:
-    type: stdlib
-- name: diff-lcs
-  version: '1.5'
-  source:
-    type: git
-    name: ruby/gem_rbs_collection
-    revision: 2443035126922ee49f775a0edb0b705896fef7c6
-    remote: https://github.com/ruby/gem_rbs_collection.git
-    repo_dir: gems
-- name: digest
-  version: '0'
-  source:
-    type: stdlib
-- name: erb
-  version: '0'
-  source:
-    type: stdlib
-- name: faraday
-  version: '2.5'
-  source:
-    type: git
-    name: ruby/gem_rbs_collection
-    revision: 2443035126922ee49f775a0edb0b705896fef7c6
-    remote: https://github.com/ruby/gem_rbs_collection.git
-    repo_dir: gems
-- name: fileutils
-  version: '0'
-  source:
-    type: stdlib
-- name: forwardable
-  version: '0'
-  source:
-    type: stdlib
-- name: hashdiff
-  version: '1.1'
-  source:
-    type: git
-    name: ruby/gem_rbs_collection
-    revision: 2443035126922ee49f775a0edb0b705896fef7c6
-    remote: https://github.com/ruby/gem_rbs_collection.git
-    repo_dir: gems
-- name: hashie
-  version: '5.0'
-  source:
-    type: git
-    name: ruby/gem_rbs_collection
-    revision: 2443035126922ee49f775a0edb0b705896fef7c6
-    remote: https://github.com/ruby/gem_rbs_collection.git
-    repo_dir: gems
-- name: i18n
-  version: '1.10'
-  source:
-    type: git
-    name: ruby/gem_rbs_collection
-    revision: 2443035126922ee49f775a0edb0b705896fef7c6
-    remote: https://github.com/ruby/gem_rbs_collection.git
-    repo_dir: gems
 - name: io-console
   version: '0'
   source:
@@ -141,50 +29,18 @@ gems:
   version: '0'
   source:
     type: stdlib
-- name: jwt
-  version: '2.5'
-  source:
-    type: git
-    name: ruby/gem_rbs_collection
-    revision: 2443035126922ee49f775a0edb0b705896fef7c6
-    remote: https://github.com/ruby/gem_rbs_collection.git
-    repo_dir: gems
 - name: language_server-protocol
   version: 3.17.0.6
   source:
     type: rubygems
-- name: lint_roller
-  version: '1.1'
-  source:
-    type: git
-    name: ruby/gem_rbs_collection
-    revision: 2443035126922ee49f775a0edb0b705896fef7c6
-    remote: https://github.com/ruby/gem_rbs_collection.git
-    repo_dir: gems
 - name: logger
-  version: '1.7'
+  version: '0'
   source:
-    type: git
-    name: ruby/gem_rbs_collection
-    revision: 2443035126922ee49f775a0edb0b705896fef7c6
-    remote: https://github.com/ruby/gem_rbs_collection.git
-    repo_dir: gems
-- name: mime-types
-  version: '3.5'
-  source:
-    type: git
-    name: ruby/gem_rbs_collection
-    revision: 2443035126922ee49f775a0edb0b705896fef7c6
-    remote: https://github.com/ruby/gem_rbs_collection.git
-    repo_dir: gems
+    type: stdlib
 - name: minitest
-  version: '5.25'
+  version: '0'
   source:
-    type: git
-    name: ruby/gem_rbs_collection
-    revision: 2443035126922ee49f775a0edb0b705896fef7c6
-    remote: https://github.com/ruby/gem_rbs_collection.git
-    repo_dir: gems
+    type: stdlib
 - name: monitor
   version: '0'
   source:
@@ -193,31 +49,11 @@ gems:
   version: 0.9.1
   source:
     type: rubygems
-- name: nokogiri
-  version: '1.11'
-  source:
-    type: git
-    name: ruby/gem_rbs_collection
-    revision: 2443035126922ee49f775a0edb0b705896fef7c6
-    remote: https://github.com/ruby/gem_rbs_collection.git
-    repo_dir: gems
 - name: oauth2
   version: 2.0.24
   source:
     type: rubygems
-- name: observer
-  version: '0.1'
-  source:
-    type: git
-    name: ruby/gem_rbs_collection
-    revision: 2443035126922ee49f775a0edb0b705896fef7c6
-    remote: https://github.com/ruby/gem_rbs_collection.git
-    repo_dir: gems
 - name: open3
-  version: '0'
-  source:
-    type: stdlib
-- name: openssl
   version: '0'
   source:
     type: stdlib
@@ -225,50 +61,10 @@ gems:
   version: '0'
   source:
     type: stdlib
-- name: parallel
-  version: '1.20'
-  source:
-    type: git
-    name: ruby/gem_rbs_collection
-    revision: 2443035126922ee49f775a0edb0b705896fef7c6
-    remote: https://github.com/ruby/gem_rbs_collection.git
-    repo_dir: gems
-- name: parser
-  version: '3.2'
-  source:
-    type: git
-    name: ruby/gem_rbs_collection
-    revision: 2443035126922ee49f775a0edb0b705896fef7c6
-    remote: https://github.com/ruby/gem_rbs_collection.git
-    repo_dir: gems
 - name: prism
   version: 1.9.0
   source:
     type: rubygems
-- name: rack
-  version: '2.2'
-  source:
-    type: git
-    name: ruby/gem_rbs_collection
-    revision: 2443035126922ee49f775a0edb0b705896fef7c6
-    remote: https://github.com/ruby/gem_rbs_collection.git
-    repo_dir: gems
-- name: rainbow
-  version: '3.0'
-  source:
-    type: git
-    name: ruby/gem_rbs_collection
-    revision: 2443035126922ee49f775a0edb0b705896fef7c6
-    remote: https://github.com/ruby/gem_rbs_collection.git
-    repo_dir: gems
-- name: rake
-  version: '13.0'
-  source:
-    type: git
-    name: ruby/gem_rbs_collection
-    revision: 2443035126922ee49f775a0edb0b705896fef7c6
-    remote: https://github.com/ruby/gem_rbs_collection.git
-    repo_dir: gems
 - name: random-formatter
   version: '0'
   source:
@@ -281,34 +77,6 @@ gems:
   version: '0'
   source:
     type: stdlib
-- name: regexp_parser
-  version: '2.8'
-  source:
-    type: git
-    name: ruby/gem_rbs_collection
-    revision: 2443035126922ee49f775a0edb0b705896fef7c6
-    remote: https://github.com/ruby/gem_rbs_collection.git
-    repo_dir: gems
-- name: ripper
-  version: '0'
-  source:
-    type: stdlib
-- name: rubocop
-  version: '1.57'
-  source:
-    type: git
-    name: ruby/gem_rbs_collection
-    revision: 2443035126922ee49f775a0edb0b705896fef7c6
-    remote: https://github.com/ruby/gem_rbs_collection.git
-    repo_dir: gems
-- name: rubocop-ast
-  version: '1.46'
-  source:
-    type: git
-    name: ruby/gem_rbs_collection
-    revision: 2443035126922ee49f775a0edb0b705896fef7c6
-    remote: https://github.com/ruby/gem_rbs_collection.git
-    repo_dir: gems
 - name: rubocop-yard
   version: 1.3.0
   source:
@@ -317,66 +85,14 @@ gems:
   version: '0'
   source:
     type: stdlib
-- name: simplecov
-  version: '0.22'
-  source:
-    type: git
-    name: ruby/gem_rbs_collection
-    revision: 2443035126922ee49f775a0edb0b705896fef7c6
-    remote: https://github.com/ruby/gem_rbs_collection.git
-    repo_dir: gems
-- name: singleton
-  version: '0'
-  source:
-    type: stdlib
 - name: snaky_hash
   version: 2.0.6
   source:
     type: rubygems
-- name: socket
-  version: '0'
-  source:
-    type: stdlib
-- name: stringio
-  version: '0'
-  source:
-    type: stdlib
-- name: tempfile
-  version: '0'
-  source:
-    type: stdlib
-- name: thor
-  version: '1.2'
-  source:
-    type: git
-    name: ruby/gem_rbs_collection
-    revision: 2443035126922ee49f775a0edb0b705896fef7c6
-    remote: https://github.com/ruby/gem_rbs_collection.git
-    repo_dir: gems
-- name: time
-  version: '0'
-  source:
-    type: stdlib
-- name: timeout
-  version: '0'
-  source:
-    type: stdlib
-- name: tmpdir
-  version: '0'
-  source:
-    type: stdlib
 - name: tsort
   version: '0'
   source:
     type: stdlib
-- name: tzinfo
-  version: '2.0'
-  source:
-    type: git
-    name: ruby/gem_rbs_collection
-    revision: 2443035126922ee49f775a0edb0b705896fef7c6
-    remote: https://github.com/ruby/gem_rbs_collection.git
-    repo_dir: gems
 - name: uri
   version: '0'
   source:
@@ -385,20 +101,4 @@ gems:
   version: 1.1.13
   source:
     type: rubygems
-- name: webmock
-  version: '3.19'
-  source:
-    type: git
-    name: ruby/gem_rbs_collection
-    revision: 2443035126922ee49f775a0edb0b705896fef7c6
-    remote: https://github.com/ruby/gem_rbs_collection.git
-    repo_dir: gems
-- name: yard
-  version: '0.9'
-  source:
-    type: git
-    name: ruby/gem_rbs_collection
-    revision: 2443035126922ee49f775a0edb0b705896fef7c6
-    remote: https://github.com/ruby/gem_rbs_collection.git
-    repo_dir: gems
 gemfile_lock_path: Gemfile.lock

--- a/rbs_collection.lock.yaml
+++ b/rbs_collection.lock.yaml
@@ -1,10 +1,34 @@
 ---
 path: ".gem_rbs_collection"
 gems:
+- name: activesupport
+  version: '7.0'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 2443035126922ee49f775a0edb0b705896fef7c6
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: addressable
+  version: '2.8'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 2443035126922ee49f775a0edb0b705896fef7c6
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
 - name: anonymous_loader
   version: 0.1.2
   source:
     type: rubygems
+- name: ast
+  version: '2.4'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 2443035126922ee49f775a0edb0b705896fef7c6
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
 - name: auth-sanitizer
   version: 0.2.2
   source:
@@ -21,6 +45,94 @@ gems:
   version: 4.1.2
   source:
     type: rubygems
+- name: cgi
+  version: '0.5'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 2443035126922ee49f775a0edb0b705896fef7c6
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: concurrent-ruby
+  version: '1.1'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 2443035126922ee49f775a0edb0b705896fef7c6
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: connection_pool
+  version: '2.4'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 2443035126922ee49f775a0edb0b705896fef7c6
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: date
+  version: '0'
+  source:
+    type: stdlib
+- name: delegate
+  version: '0'
+  source:
+    type: stdlib
+- name: diff-lcs
+  version: '1.5'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 2443035126922ee49f775a0edb0b705896fef7c6
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: digest
+  version: '0'
+  source:
+    type: stdlib
+- name: erb
+  version: '0'
+  source:
+    type: stdlib
+- name: faraday
+  version: '2.5'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 2443035126922ee49f775a0edb0b705896fef7c6
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: fileutils
+  version: '0'
+  source:
+    type: stdlib
+- name: forwardable
+  version: '0'
+  source:
+    type: stdlib
+- name: hashdiff
+  version: '1.1'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 2443035126922ee49f775a0edb0b705896fef7c6
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: hashie
+  version: '5.0'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 2443035126922ee49f775a0edb0b705896fef7c6
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: i18n
+  version: '1.10'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 2443035126922ee49f775a0edb0b705896fef7c6
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
 - name: io-console
   version: '0'
   source:
@@ -29,18 +141,50 @@ gems:
   version: '0'
   source:
     type: stdlib
+- name: jwt
+  version: '2.5'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 2443035126922ee49f775a0edb0b705896fef7c6
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
 - name: language_server-protocol
   version: 3.17.0.6
   source:
     type: rubygems
+- name: lint_roller
+  version: '1.1'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 2443035126922ee49f775a0edb0b705896fef7c6
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
 - name: logger
-  version: '0'
+  version: '1.7'
   source:
-    type: stdlib
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 2443035126922ee49f775a0edb0b705896fef7c6
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: mime-types
+  version: '3.5'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 2443035126922ee49f775a0edb0b705896fef7c6
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
 - name: minitest
-  version: '0'
+  version: '5.25'
   source:
-    type: stdlib
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 2443035126922ee49f775a0edb0b705896fef7c6
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
 - name: monitor
   version: '0'
   source:
@@ -49,11 +193,31 @@ gems:
   version: 0.9.1
   source:
     type: rubygems
+- name: nokogiri
+  version: '1.11'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 2443035126922ee49f775a0edb0b705896fef7c6
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
 - name: oauth2
   version: 2.0.24
   source:
     type: rubygems
+- name: observer
+  version: '0.1'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 2443035126922ee49f775a0edb0b705896fef7c6
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
 - name: open3
+  version: '0'
+  source:
+    type: stdlib
+- name: openssl
   version: '0'
   source:
     type: stdlib
@@ -61,10 +225,50 @@ gems:
   version: '0'
   source:
     type: stdlib
+- name: parallel
+  version: '1.20'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 2443035126922ee49f775a0edb0b705896fef7c6
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: parser
+  version: '3.2'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 2443035126922ee49f775a0edb0b705896fef7c6
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
 - name: prism
   version: 1.9.0
   source:
     type: rubygems
+- name: rack
+  version: '2.2'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 2443035126922ee49f775a0edb0b705896fef7c6
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: rainbow
+  version: '3.0'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 2443035126922ee49f775a0edb0b705896fef7c6
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: rake
+  version: '13.0'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 2443035126922ee49f775a0edb0b705896fef7c6
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
 - name: random-formatter
   version: '0'
   source:
@@ -77,6 +281,34 @@ gems:
   version: '0'
   source:
     type: stdlib
+- name: regexp_parser
+  version: '2.8'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 2443035126922ee49f775a0edb0b705896fef7c6
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: ripper
+  version: '0'
+  source:
+    type: stdlib
+- name: rubocop
+  version: '1.57'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 2443035126922ee49f775a0edb0b705896fef7c6
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: rubocop-ast
+  version: '1.46'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 2443035126922ee49f775a0edb0b705896fef7c6
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
 - name: rubocop-yard
   version: 1.3.0
   source:
@@ -85,14 +317,66 @@ gems:
   version: '0'
   source:
     type: stdlib
+- name: simplecov
+  version: '0.22'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 2443035126922ee49f775a0edb0b705896fef7c6
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: singleton
+  version: '0'
+  source:
+    type: stdlib
 - name: snaky_hash
   version: 2.0.6
   source:
     type: rubygems
+- name: socket
+  version: '0'
+  source:
+    type: stdlib
+- name: stringio
+  version: '0'
+  source:
+    type: stdlib
+- name: tempfile
+  version: '0'
+  source:
+    type: stdlib
+- name: thor
+  version: '1.2'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 2443035126922ee49f775a0edb0b705896fef7c6
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: time
+  version: '0'
+  source:
+    type: stdlib
+- name: timeout
+  version: '0'
+  source:
+    type: stdlib
+- name: tmpdir
+  version: '0'
+  source:
+    type: stdlib
 - name: tsort
   version: '0'
   source:
     type: stdlib
+- name: tzinfo
+  version: '2.0'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 2443035126922ee49f775a0edb0b705896fef7c6
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
 - name: uri
   version: '0'
   source:
@@ -101,4 +385,20 @@ gems:
   version: 1.1.13
   source:
     type: rubygems
+- name: webmock
+  version: '3.19'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 2443035126922ee49f775a0edb0b705896fef7c6
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: yard
+  version: '0.9'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 2443035126922ee49f775a0edb0b705896fef7c6
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
 gemfile_lock_path: Gemfile.lock

--- a/test/unit/test_attachments.rb
+++ b/test/unit/test_attachments.rb
@@ -101,19 +101,13 @@ class TestAttachments < ClassTest
   end
 
   # @return [String]
-  # @sg-ignore tool-limitation:gvar-reassignment-not-tracked
-  #   TestAttachments#capture_attachments_run return type could not be inferred.
-  #   Reassigning a $-prefixed global to a new type is never tracked at all -- unlike an
-  #   equivalent local var or ivar reassignment (both work fine), $stdout's new StringIO
-  #   type never applies to the reassigned global, so $stdout.string below can't resolve
-  #   either. Related to but distinct from castwide/solargraph#663 (that one is about
-  #   reading a predefined global never assigned in the file at all, not a
-  #   reassignment-tracking gap). Not filed upstream.
+  # @sg-ignore tool-limitation:pr-1282-follow-on
+  #   https://github.com/castwide/solargraph/pull/1282#issuecomment-5272732583
   def capture_attachments_run
     old_stdout = $stdout
     $stdout = StringIO.new
     Checkoff::Attachments.run
-    # @sg-ignore tool-limitation:gvar-reassignment-not-tracked
+    # @sg-ignore tool-limitation:pr-1282-follow-on
     #   Same cause as this method's own sg-ignore above.
     $stdout.string
   ensure


### PR DESCRIPTION
## Summary

Tracks the `apiology/solargraph` fork's `2026-08-04` branch forward through two pin bumps (`1933086` ��� `cd567a0` ��� `a6942fc`), resolving upstream fixes as they land and filing/updating comments on the still-open PRs whose gaps remain:

- `1933086` ��� `cd567a0`: picks up `castwide/solargraph#1288`, which fixes `castwide/solargraph#1286` ��� removes the now-unneeded `sg-ignore` in [`selector_classes/section.rb`](lib/checkoff/internal/selector_classes/section.rb).
- `cd567a0` ��� `a6942fc`: picks up `castwide/solargraph#1290` (fixes `#1289`) and an updated `castwide/solargraph#1281` (RBS type-alias resolution) ��� removes the now-unneeded `sg-ignore` in [`bootstrap_local_overcommit.rb`](.git-hooks/bootstrap_local_overcommit.rb).
- Retags two still-open markers to reflect live upstream discussion opened this session: `test_attachments.rb`'s `$stdout` reassignment-tracking gap ��� `pr-1282-follow-on` (its prior "local var/ivar reassignment works fine" claim was verified false and corrected), and `attachments.rb`'s `Net::HTTP.start` generic block-form gap ��� `pr-1290-follow-up` (confirmed `#1290`'s YARD-`@overload` fix doesn't reach RBS-declared generic overloads, isolated to a keyword-argument-triggered repro).

## Test plan

- [x] `solargraph typecheck --level strong` ��� 0 problems
- [x] `rake test` ��� 329 tests, 0 failures
- [x] `rubocop` ��� no offenses
