### PR TITLE
Stop checking checkoff against rubygems in its own build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -242,12 +242,6 @@ jobs:
       - image: cimg/base:current
     steps:
       - set_up_environment
-      - when:
-          condition:
-            equal: [<< pipeline.git.branch >>, "main"]
-          steps:
-            - update_dependencies:
-                gems: checkoff
       - run:
           label: Verify deltas
           command: |


### PR DESCRIPTION
checkoff has published no gem since 0.258.0 on 2026-08-03. `main`'s `build` job fails, so `publish_gem` never runs (it shows `not_run`). Anything that needs a newer checkoff is stuck behind that — including apiology/plate-spinner, which carries suppression markers waiting on the typing work merged in https://github.com/apiology/checkoff/pull/476.

## Cause

The `build` job runs `update_dependencies` with `gems: checkoff` — checkoff checking itself against rubygems:

```
+ BUNDLED_VERSION=0.259.0
+ '[' 0.258.0 '!=' 0.259.0 ']'
+ echo 'Manually upgrade to checkoff' v0.258.0
Manually upgrade to checkoff v0.258.0
+ exit 1
```

`lib/checkoff/version.rb` went to 0.259.0 in https://github.com/apiology/checkoff/commit/3765374b835b387bc024e35d80a14306e4022a85 on 2026-08-03. Every main build since compares that not-yet-published version against rubygems' published 0.258.0 and exits 1 — which blocks the publish that would make the two agree. Confirmed identical on two separate main merges:

- https://app.circleci.com/workflow/7d27896a-4255-4214-b73e-81f2f36deefb (the #476 merge)
- https://app.circleci.com/workflow/b392bafb-6300-48cc-86fc-265161fe99e8 (the #475 merge)

The `quality` workflow passes on both; only `build` fails.

## Fix

Remove the invocation. checkoff is not a dependency of checkoff — its `Gemfile` uses `gemspec` — and `docs/cookiecutter_input.json` already answers `use_checkoff: "No"`. The version in `version.rb` leading rubygems is the designed state between the `publish_gem` bump and the release that follows.

The check is for downstream consumers: `publish_gem` ends with `rake trigger_next_builds`, which kicks off apiology/plate-spinner so *its* `update_dependencies` picks up the new checkoff. The `update_dependencies` command definition stays, since that is what the template renders for a "No" answer.

## Upstream root cause (not fixed here)

The cookiecutter templates emit this block under `{% if cookiecutter.use_checkoff %}`, which is truthy for the string `"No"`, so every baked repo gets it regardless of the answer. Correct form is `{% if cookiecutter.use_checkoff == "Yes" %}` in cookiecutter-gem / cookiecutter-ruby / cookiecutter-rails. apiology/gem_boilerplate answers "No" too and is already red at the same step, for the related reason that checkoff is not in its bundle at all.

Until the template is fixed, `make update_from_cookiecutter` will reinstate this block here.

## Two things remain after this merges

No gem should be expected immediately:

1. The 2026-08-03 `publish_gem` run (https://app.circleci.com/workflow/c8bf72ad-0096-4466-8cd8-557222b48ccd) also died, in `make release` at `release:guard_clean`: `rake aborted! There are files that need to be committed first.` That did not reproduce locally — a full rerun of the release prerequisite chain (with `Gemfile.lock` touched to force `bin/tapioca gems`, `bin/tapioca annotations`, `bin/rbs collection install`) left the tree clean. Leading candidate is `rbs_collection.lock.yaml` regenerating against a newer upstream `ruby/gem_rbs_collection` revision than the one committed; the other tracked outputs of that chain are `sorbet/rbi/gems/*.rbi` and `sorbet/rbi/annotations/*.rbi`.
2. `bump ... minor` runs before `make release` in `publish_gem`, so the next green main publishes **0.260.0**. 0.259.0 will not ship via CI.

## Verification

- `make quality` — exit 0, all 16 overcommit hooks OK
- `make build-typecheck` — exit 0
- `circleci config validate` — valid
- clean tree after each

This PR was written by Claude (Claude Code), operated by @apiology.
