### PR TITLE
Give project_to_h per-key return types

### DIFF
--- a/lib/checkoff/internal/project_hashes.rb
+++ b/lib/checkoff/internal/project_hashes.rb
@@ -13,7 +13,12 @@ module Checkoff
       # @param project [String, :not_specified, :my_tasks, nil] - a String is a
       #   project name
       #
-      # @return [Hash{String => Object}]
+      # @return [Hash{"unwrapped" => Hash{"custom_fields" => Hash{String =>
+      #   Hash{"gid" => String} & Hash{"name" => String} &
+      #   Hash{"display_value" => String, nil} & Hash{"number_value" => Float, Integer, nil} &
+      #   Hash{"text_value" => String, nil} & Hash{"enum_value" => Hash{String => String}, nil}}}} &
+      #   Hash{"project" => String, Symbol, nil} & Hash{"gid" => String} &
+      #   Hash{"name" => String} & Hash{"custom_fields" => Array<Hash{String => Object}>, nil}]
       def project_to_h(project_obj, project: :not_specified)
         project = project_obj.name if project == :not_specified
         project_hash = { **project_obj.to_h, 'project' => project }

--- a/lib/checkoff/internal/project_hashes.rb
+++ b/lib/checkoff/internal/project_hashes.rb
@@ -16,20 +16,25 @@ module Checkoff
       # @param project [String, :not_specified, :my_tasks, nil] - a String is a
       #   project name
       #
-      # @return [Hash{"unwrapped" => Hash{"custom_fields" => Hash{String =>
-      #   Hash{"gid" => String} & Hash{"name" => String} &
-      #   Hash{"display_value" => String, nil} &
-      #   Hash{"number_value" => Float, Integer, nil} &
-      #   Hash{"text_value" => String, nil} &
-      #   Hash{"enum_value" => Hash{String => String}, nil}}}} &
-      #   Hash{"project" => String, Symbol, nil} & Hash{"gid" => String} &
+      # @return [Hash{"project" => String, Symbol, nil} &
+      #   Hash{"gid" => String} &
       #   Hash{"name" => String} &
       #   Hash{"custom_fields" => Array<
-      #   Hash{"gid" => String} & Hash{"name" => String} &
-      #   Hash{"display_value" => String, nil} &
-      #   Hash{"number_value" => Float, Integer, nil} &
-      #   Hash{"text_value" => String, nil} &
-      #   Hash{"enum_value" => Hash{String => String}, nil}>, nil}]
+      #     Hash{"gid" => String} &
+      #     Hash{"name" => String} &
+      #     Hash{"display_value" => String, nil} &
+      #     Hash{"number_value" => Float, Integer, nil} &
+      #     Hash{"text_value" => String, nil} &
+      #     Hash{"enum_value" => Hash{String => String}, nil}
+      #   >, nil} &
+      #   Hash{"unwrapped" => Hash{"custom_fields" => Hash{String =>
+      #     Hash{"gid" => String} &
+      #     Hash{"name" => String} &
+      #     Hash{"display_value" => String, nil} &
+      #     Hash{"number_value" => Float, Integer, nil} &
+      #     Hash{"text_value" => String, nil} &
+      #     Hash{"enum_value" => Hash{String => String}, nil}
+      #   }}}]
       def project_to_h(project_obj, project: :not_specified)
         project = project_obj.name if project == :not_specified
         project_hash = { **project_obj.to_h, 'project' => project }

--- a/lib/checkoff/internal/project_hashes.rb
+++ b/lib/checkoff/internal/project_hashes.rb
@@ -12,13 +12,23 @@ module Checkoff
       # @param project_obj [Asana::Resources::Project]
       # @param project [String, :not_specified, :my_tasks, nil] - a String is a
       #   project name
+      # The two custom_fields entries below hold the same records: the top-level
+      # array is what Asana returns, and unwrapped re-keys those records by name.
       #
       # @return [Hash{"unwrapped" => Hash{"custom_fields" => Hash{String =>
       #   Hash{"gid" => String} & Hash{"name" => String} &
-      #   Hash{"display_value" => String, nil} & Hash{"number_value" => Float, Integer, nil} &
-      #   Hash{"text_value" => String, nil} & Hash{"enum_value" => Hash{String => String}, nil}}}} &
+      #   Hash{"display_value" => String, nil} &
+      #   Hash{"number_value" => Float, Integer, nil} &
+      #   Hash{"text_value" => String, nil} &
+      #   Hash{"enum_value" => Hash{String => String}, nil}}}} &
       #   Hash{"project" => String, Symbol, nil} & Hash{"gid" => String} &
-      #   Hash{"name" => String} & Hash{"custom_fields" => Array<Hash{String => Object}>, nil}]
+      #   Hash{"name" => String} &
+      #   Hash{"custom_fields" => Array<
+      #   Hash{"gid" => String} & Hash{"name" => String} &
+      #   Hash{"display_value" => String, nil} &
+      #   Hash{"number_value" => Float, Integer, nil} &
+      #   Hash{"text_value" => String, nil} &
+      #   Hash{"enum_value" => Hash{String => String}, nil}>, nil}]
       def project_to_h(project_obj, project: :not_specified)
         project = project_obj.name if project == :not_specified
         project_hash = { **project_obj.to_h, 'project' => project }

--- a/lib/checkoff/internal/project_hashes.rb
+++ b/lib/checkoff/internal/project_hashes.rb
@@ -9,11 +9,12 @@ module Checkoff
       # @param _deps [Hash]
       def initialize(_deps = {}); end
 
+      # The two custom_fields entries below hold the same records: the top-level
+      # array is what Asana returns, and unwrapped re-keys those records by name.
+      #
       # @param project_obj [Asana::Resources::Project]
       # @param project [String, :not_specified, :my_tasks, nil] - a String is a
       #   project name
-      # The two custom_fields entries below hold the same records: the top-level
-      # array is what Asana returns, and unwrapped re-keys those records by name.
       #
       # @return [Hash{"unwrapped" => Hash{"custom_fields" => Hash{String =>
       #   Hash{"gid" => String} & Hash{"name" => String} &

--- a/lib/checkoff/projects.rb
+++ b/lib/checkoff/projects.rb
@@ -212,7 +212,12 @@ module Checkoff
     # @param project [String, :not_specified, :my_tasks, nil] - a String is a
     #   project name
     #
-    # @return [Hash{String => Object}]
+    # @return [Hash{"unwrapped" => Hash{"custom_fields" => Hash{String =>
+    #   Hash{"gid" => String} & Hash{"name" => String} &
+    #   Hash{"display_value" => String, nil} & Hash{"number_value" => Float, Integer, nil} &
+    #   Hash{"text_value" => String, nil} & Hash{"enum_value" => Hash{String => String}, nil}}}} &
+    #   Hash{"project" => String, Symbol, nil} & Hash{"gid" => String} &
+    #   Hash{"name" => String} & Hash{"custom_fields" => Array<Hash{String => Object}>, nil}]
     def project_to_h(project_obj, project: :not_specified)
       project_hashes.project_to_h(project_obj, project:)
     end

--- a/lib/checkoff/projects.rb
+++ b/lib/checkoff/projects.rb
@@ -212,12 +212,7 @@ module Checkoff
     # @param project [String, :not_specified, :my_tasks, nil] - a String is a
     #   project name
     #
-    # @return [Hash{"unwrapped" => Hash{"custom_fields" => Hash{String =>
-    #   Hash{"gid" => String} & Hash{"name" => String} &
-    #   Hash{"display_value" => String, nil} & Hash{"number_value" => Float, Integer, nil} &
-    #   Hash{"text_value" => String, nil} & Hash{"enum_value" => Hash{String => String}, nil}}}} &
-    #   Hash{"project" => String, Symbol, nil} & Hash{"gid" => String} &
-    #   Hash{"name" => String} & Hash{"custom_fields" => Array<Hash{String => Object}>, nil}]
+    # @return (see Checkoff::Internal::ProjectHashes#project_to_h)
     def project_to_h(project_obj, project: :not_specified)
       project_hashes.project_to_h(project_obj, project:)
     end


### PR DESCRIPTION
Consumers of `project_to_h` could not `.fetch` anything out of the result. The
declared `@return [Hash{String => Object}]` gave every value type `Object`,
which has almost no methods, so chains like
`project_data.fetch('unwrapped').fetch('custom_fields').fetch(name).fetch('number_value')`
were Solargraph errors and downstream repos carried suppressions for them. That
chain now typechecks, with `number_value` resolving to `Float, Integer, nil`.

The shape is declared as an intersection of single-key literal Hash types, one
conjunct per key. A union would be wrong — it gives every key the union of all
value types — and so would a `& Hash{String => Object}` catch-all conjunct,
which Solargraph collapses the same way. There is therefore no catch-all:
fetching an undeclared key is now an error rather than `Object`.

The type declares the keys the unwrap path populates when custom fields exist,
not every runtime shape. A project with no custom fields leaves `unwrapped`
empty, and Asana fills only the value key matching each field's subtype.

Comments only, no behavior change.

This PR was written by Claude Code on behalf of @apiology.
