### PR TITLE
Self-heal config/env.local symlink in worktrees

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -63,6 +63,31 @@ fi
 # ~/.cache/env-local-probe/<worktree-basename>.log (also .env-local-probe-path).
 ENV_LOCAL_PROBE_SOURCE=envrc ENV_LOCAL_PROBE_QUIET=1 ./bin/probe_env_local || true
 
+# A worktree freshly created by agent tooling can start running .envrc
+# before whatever external process provisions config/env.local's symlink
+# into it has caught up -- observed as this check finding neither -L nor -r
+# true yet, even though the symlink reliably exists moments later once
+# provisioning finishes. Rather than waiting on that external process, just
+# create the symlink ourselves: every worktree shares one main checkout
+# (found via git's own common .git dir, so this isn't tied to any one
+# machine's checkout path), and that main checkout's config/env.local is
+# the actual mounted file/FIFO all worktrees are meant to point at. Doing
+# this ourselves is instant and deterministic instead of a bounded guess,
+# and it's a no-op once the external process's own symlink lands (same
+# target, so re-running this is harmless). Only fires when
+# config/env.local doesn't exist at all yet (ENOENT) -- an existing
+# unreadable file (e.g. a FIFO with no writer) is a real "no mount" case,
+# not a race, and creating a symlink wouldn't fix that anyway.
+if [[ ! -e config/env.local && ! -L config/env.local ]]; then
+  main_checkout_git_dir="$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)"
+  main_checkout="${main_checkout_git_dir%/.git}"
+  if [[ -n "${main_checkout}" ]] \
+     && [[ "${main_checkout}" != "${PWD}" ]] \
+     && [[ -e "${main_checkout}/config/env.local" ]]; then
+    ln -s "${main_checkout}/config/env.local" config/env.local
+  fi
+fi
+
 # -L: worktree symlink to mounted env.local (FIFO; -r is false without a writer).
 # -r: regular file or FIFO with an active reader/writer.
 if [[ -L config/env.local || -r config/env.local ]]; then


### PR DESCRIPTION
**Problem:**

A worktree created by agent tooling fails `direnv exec` outright when `config/env.local` has not yet been symlinked in from the primary checkout, because `.envrc` falls through to a 1Password CLI call that has no account configured in that environment.

```
$ direnv exec . env
No accounts configured for use with 1Password CLI.
...
direnv: error exit status 1
```

This happens because the symlink is normally provisioned by an external process (a Cursor hook, or a manual `ln -s`) that has not caught up yet when a fresh worktree's `.envrc` first runs, so the `-L`/`-r` check on `config/env.local` finds neither true and falls into the `op run` branch.

**Solution:**

When `config/env.local` is simply missing (ENOENT, not an existing unreadable file), `.envrc` now creates the symlink itself from the primary checkout — found via `git rev-parse --path-format=absolute --git-common-dir`, so it is not tied to any one worktree-path convention.
